### PR TITLE
Restore Discord attachments with R2 download button

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+DISCORD_TOKEN=your-discord-bot-token
+DISCORD_CLIENT_ID=your-discord-application-id
+DATABASE_URL=postgres://user:password@host:5432/database
+# Optional: comma-separated guild IDs for registering commands instantly during development
+# DEV_GUILD_IDS=123456789012345678,234567890123456789
+# Optional: override download directory (defaults to ./data)
+# BOT_DATA_DIR=/absolute/path/to/data
+# Optional: override Discord upload size limit (defaults to 8 MiB)
+# MAX_UPLOAD_BYTES=8388608
+# Optional: custom ffmpeg path (defaults to "ffmpeg")
+# FFMPEG_PATH=/usr/local/bin/ffmpeg
+# Cloudflare R2 configuration
+R2_ACCOUNT_ID=your-account-id
+R2_ACCESS_KEY_ID=your-access-key-id
+R2_SECRET_ACCESS_KEY=your-secret-access-key
+R2_BUCKET_NAME=your-bucket-name
+# Base URL used to share uploaded files (e.g. https://cdn.example.com)
+R2_PUBLIC_BASE_URL=https://your-public-domain
+# Optional: custom API endpoint (defaults to https://<account>.r2.cloudflarestorage.com)
+# R2_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
+# Optional: prefix for uploaded objects
+# R2_OBJECT_PREFIX=discord-bluesky/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/node_modules
+/.env
+.env
+/data/*
+!/data/.gitkeep

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# ---- Base image ----
+FROM node:20-slim
+
+# Install ffmpeg (and certs for HTTPS). Keep the layer small.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ffmpeg ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Workdir inside the container
+WORKDIR /app
+
+# Copy lockfiles first for better Docker layer caching
+# (COPY will ignore files excluded by .dockerignore)
+COPY package*.json ./
+
+# Set environment early (used by npm ci below)
+ARG NODE_ENV=production
+ENV NODE_ENV=$NODE_ENV
+
+# Install production deps
+# Falls back to `npm install` if there's no lockfile
+RUN if [ -f package-lock.json ]; then \
+      npm ci --omit=dev; \
+    else \
+      npm install --omit=dev; \
+    fi
+
+# Copy the rest of your source
+COPY . .
+
+# Environment used by your code
+# DOWNLOAD_ROOT: where your downloader writes temp files on Railway
+# FFMPEG_PATH: explicit path to the ffmpeg binary we installed
+ENV DOWNLOAD_ROOT=/tmp \
+    FFMPEG_PATH=/usr/bin/ffmpeg
+
+# Run as non-root for safety
+# USER node
+
+# If your app exposes an HTTP port, optionally uncomment:
+# EXPOSE 3000
+
+# Start the app:
+# - If you have "start": "node index.js" (or similar) in package.json, this is perfect.
+# - If you *don't* have an npm start script, replace this with:  CMD ["node", "index.js"]
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ A Discord bot that watches for Bluesky post links, downloads their video content
 
 - `/bluesky-listener enabled:<true|false> silent:<true|false>` – Toggle automatic downloads when Bluesky links appear in the guild and whether reposts should be silent.
 - `/bluesky-download url:<post-url> silent:<true|false>` – Fetch a specific Bluesky post immediately, optionally returning only the video URL.
-- `/bluesky-bulk urls:<post-urls> silent:<true|false>` – Download up to 10 Bluesky posts at once using a comma-separated list. The bot replies with a progress embed, follows up with each video (or just the download links when silent mode is enabled), and summarizes any errors after completion.
+- `/bluesky-bulk urls:<post-urls> silent:<true|false>` – Download multiple Bluesky posts at once using a comma-separated list. The bot replies with a progress embed, follows up with each video (or just the download links when silent mode is enabled), and summarizes any errors after completion.
 
 ### Automatic Downloads
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,82 @@
-# demo-progs
+# Bluesky Discord Downloader Bot
+
+A Discord bot that watches for Bluesky post links, downloads their video content, and reposts the video inside your server. The bot supports slash commands, PostgreSQL-backed guild preferences, and streams downloads to avoid excessive memory usage.
+
+## Features
+
+- Slash commands for toggling automatic Bluesky monitoring and on-demand downloads.
+- PostgreSQL storage for per-guild listener preferences.
+- Streams HLS segments directly to disk inside the bot's data directory until uploads complete.
+- Uploads finished downloads to Cloudflare R2 and reposts them as Discord attachments with a download button linking to the Cloudflare copy.
+- Optional silent mode that posts only the Discord video attachment, with embeds available when desired.
+- Optional guild-specific command registration for faster iteration during development.
+- Automatically remuxes MPEG-TS HLS variants into MP4 with ffmpeg for reliable Discord playback.
+
+## Prerequisites
+
+- Node.js 18 or newer.
+- A running PostgreSQL database.
+- A Discord application with a bot token and the `MESSAGE CONTENT INTENT` enabled.
+- `ffmpeg` installed and available on the system `PATH` (or configure `FFMPEG_PATH`).
+
+## Getting Started
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Copy `.env.example` to `.env` and fill in your credentials:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   | Variable | Description |
+   |----------|-------------|
+   | `DISCORD_TOKEN` | Bot token from the Discord Developer Portal. |
+   | `DISCORD_CLIENT_ID` | Application (client) ID. |
+   | `DATABASE_URL` | PostgreSQL connection string. |
+   | `DEV_GUILD_IDS` | *(Optional)* Comma-separated guild IDs for instant command registration. |
+   | `BOT_DATA_DIR` | *(Optional)* Absolute path to the download directory (defaults to `./data`). |
+   | `MAX_UPLOAD_BYTES` | *(Optional)* Maximum download size in bytes (defaults to 8 MiB). |
+   | `R2_ACCOUNT_ID` | Cloudflare account ID for the R2 bucket. |
+   | `R2_ACCESS_KEY_ID` | Cloudflare R2 access key ID. |
+   | `R2_SECRET_ACCESS_KEY` | Cloudflare R2 secret access key. |
+   | `R2_BUCKET_NAME` | Cloudflare R2 bucket used to store uploaded videos. |
+   | `R2_PUBLIC_BASE_URL` | Public base URL that serves files from the R2 bucket. |
+   | `FFMPEG_PATH` | *(Optional)* Path to the ffmpeg binary (defaults to `ffmpeg`). |
+   | `R2_ENDPOINT` | *(Optional)* Override the R2 S3-compatible endpoint. |
+   | `R2_OBJECT_PREFIX` | *(Optional)* Prefix to apply to every uploaded object key. |
+
+3. Ensure your database is reachable with the provided URL. The bot will create the `guild_settings` table on startup if it does not already exist.
+
+4. Start the bot:
+
+   ```bash
+   npm start
+   ```
+
+## Usage
+
+### Slash Commands
+
+- `/bluesky-listener enabled:<true|false> silent:<true|false>` – Toggle automatic downloads when Bluesky links appear in the guild and whether reposts should be silent.
+- `/bluesky-download url:<post-url> silent:<true|false>` – Fetch a specific Bluesky post immediately, optionally returning only the video URL.
+
+### Automatic Downloads
+
+When the listener is enabled for a guild, every new message containing a Bluesky post URL triggers a download. The bot streams the video to a temporary file within the data directory, uploads it to Cloudflare R2, and cleans up the file afterwards. The reposted message attaches the video directly in Discord and, unless silent mode is enabled, adds an informative embed plus a download button that links to the Cloudflare-hosted copy.
+
+HLS variants that use MPEG-TS segments are remuxed (no re-encode) into `.mp4` files via ffmpeg before upload so Discord can play them inline. Fragmented MP4 variants prepend the required initialization segment before their media segments so the resulting `.mp4` files play inline in Discord.
+
+## Deployment Tips
+
+- Grant the bot the `Read Message History`, `Read Messages/View Channels`, `Send Messages`, and `Attach Files` permissions in each guild where it should operate.
+- The default download directory is `./data`; ensure the process has write permissions. For Docker deployments, mount a volume and set `BOT_DATA_DIR` accordingly.
+- Consider setting `PG_MAX_CLIENTS` or `PG_IDLE_TIMEOUT_MS` environment variables to fine-tune PostgreSQL connection pooling.
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ A Discord bot that watches for Bluesky post links, downloads their video content
 
 - `/bluesky-listener enabled:<true|false> silent:<true|false>` – Toggle automatic downloads when Bluesky links appear in the guild and whether reposts should be silent.
 - `/bluesky-download url:<post-url> silent:<true|false>` – Fetch a specific Bluesky post immediately, optionally returning only the video URL.
+- `/bluesky-bulk urls:<post-urls> silent:<true|false>` – Download up to 10 Bluesky posts at once using a comma-separated list. The bot replies with a progress embed, follows up with each video (or just the download links when silent mode is enabled), and summarizes any errors after completion.
 
 ### Automatic Downloads
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Discord bot that watches for Bluesky post links, downloads their video content
 - PostgreSQL storage for per-guild listener preferences.
 - Streams HLS segments directly to disk inside the bot's data directory until uploads complete.
 - Uploads finished downloads to Cloudflare R2 and reposts them as Discord attachments with a download button linking to the Cloudflare copy.
+- Automatically falls back to sharing only the Cloudflare link when a video exceeds the configured Discord upload limit.
 - Optional silent mode that posts only the Discord video attachment, with embeds available when desired.
 - Optional guild-specific command registration for faster iteration during development.
 - Automatically remuxes MPEG-TS HLS variants into MP4 with ffmpeg for reliable Discord playback.
@@ -68,7 +69,7 @@ A Discord bot that watches for Bluesky post links, downloads their video content
 
 ### Automatic Downloads
 
-When the listener is enabled for a guild, every new message containing a Bluesky post URL triggers a download. The bot streams the video to a temporary file within the data directory, uploads it to Cloudflare R2, and cleans up the file afterwards. The reposted message attaches the video directly in Discord and, unless silent mode is enabled, adds an informative embed plus a download button that links to the Cloudflare-hosted copy.
+When the listener is enabled for a guild, every new message containing a Bluesky post URL triggers a download. The bot streams the video to a temporary file within the data directory, uploads it to Cloudflare R2, and cleans up the file afterwards. The reposted message attaches the video directly in Discord when it fits under the configured size limit (default 8 MiB) and, unless silent mode is enabled, adds an informative embed plus a download button that links to the Cloudflare-hosted copy. Videos that exceed the size cap skip the attachment and instead share the Cloudflare URL alongside the same download button so members can still access the video.
 
 HLS variants that use MPEG-TS segments are remuxed (no re-encode) into `.mp4` files via ffmpeg before upload so Discord can play them inline. Fragmented MP4 variants prepend the required initialization segment before their media segments so the resulting `.mp4` files play inline in Discord.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2284 @@
+{
+  "name": "demo-progs",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "demo-progs",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/api": "^0.16.11",
+        "@aws-sdk/client-s3": "^3.899.0",
+        "discord.js": "^14.22.1",
+        "dotenv": "^17.2.3",
+        "m3u8-parser": "^7.2.0",
+        "pg": "^8.16.3"
+      }
+    },
+    "node_modules/@atproto/api": {
+      "version": "0.16.11",
+      "resolved": "https://registry.npmjs.org/@atproto/api/-/api-0.16.11.tgz",
+      "integrity": "sha512-1dhfQNHiclb102RW+Ea8Nft5olfqU0Ev/vlQaSX6mWNo1aP5zT+sPODJ8+BTUOYk3vcuvL7QMkqA/rLYy2PMyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/common-web": "^0.4.3",
+        "@atproto/lexicon": "^0.5.1",
+        "@atproto/syntax": "^0.4.1",
+        "@atproto/xrpc": "^0.7.5",
+        "await-lock": "^2.2.2",
+        "multiformats": "^9.9.0",
+        "tlds": "^1.234.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/common-web": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.4.3.tgz",
+      "integrity": "sha512-nRDINmSe4VycJzPo6fP/hEltBcULFxt9Kw7fQk6405FyAWZiTluYHlXOnU7GkQfeUK44OENG1qFTBcmCJ7e8pg==",
+      "license": "MIT",
+      "dependencies": {
+        "graphemer": "^1.4.0",
+        "multiformats": "^9.9.0",
+        "uint8arrays": "3.0.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/lexicon": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.5.1.tgz",
+      "integrity": "sha512-y8AEtYmfgVl4fqFxqXAeGvhesiGkxiy3CWoJIfsFDDdTlZUC8DFnZrYhcqkIop3OlCkkljvpSJi1hbeC1tbi8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/common-web": "^0.4.3",
+        "@atproto/syntax": "^0.4.1",
+        "iso-datestring-validator": "^2.2.2",
+        "multiformats": "^9.9.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/syntax": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.4.1.tgz",
+      "integrity": "sha512-CJdImtLAiFO+0z3BWTtxwk6aY5w4t8orHTMVJgkf++QRJWTxPbIFko/0hrkADB7n2EruDxDSeAgfUGehpH6ngw==",
+      "license": "MIT"
+    },
+    "node_modules/@atproto/xrpc": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.7.5.tgz",
+      "integrity": "sha512-MUYNn5d2hv8yVegRL0ccHvTHAVj5JSnW07bkbiaz96UH45lvYNRVwt44z+yYVnb0/mvBzyD3/ZQ55TRGt7fHkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lexicon": "^0.5.1",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.899.0.tgz",
+      "integrity": "sha512-m/XQT0Rew4ff1Xmug+8n7f3uwom2DhbPwKWjUpluKo8JNCJJTIlfFSe1tnSimeE7RdLcIigK0YpvE50OjZZHGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/credential-provider-node": "3.899.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.893.0",
+        "@aws-sdk/middleware-expect-continue": "3.893.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.899.0",
+        "@aws-sdk/middleware-host-header": "3.893.0",
+        "@aws-sdk/middleware-location-constraint": "3.893.0",
+        "@aws-sdk/middleware-logger": "3.893.0",
+        "@aws-sdk/middleware-recursion-detection": "3.893.0",
+        "@aws-sdk/middleware-sdk-s3": "3.899.0",
+        "@aws-sdk/middleware-ssec": "3.893.0",
+        "@aws-sdk/middleware-user-agent": "3.899.0",
+        "@aws-sdk/region-config-resolver": "3.893.0",
+        "@aws-sdk/signature-v4-multi-region": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-endpoints": "3.895.0",
+        "@aws-sdk/util-user-agent-browser": "3.893.0",
+        "@aws-sdk/util-user-agent-node": "3.899.0",
+        "@aws-sdk/xml-builder": "3.894.0",
+        "@smithy/config-resolver": "^4.2.2",
+        "@smithy/core": "^3.13.0",
+        "@smithy/eventstream-serde-browser": "^4.1.1",
+        "@smithy/eventstream-serde-config-resolver": "^4.2.1",
+        "@smithy/eventstream-serde-node": "^4.1.1",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/hash-blob-browser": "^4.1.1",
+        "@smithy/hash-node": "^4.1.1",
+        "@smithy/hash-stream-node": "^4.1.1",
+        "@smithy/invalid-dependency": "^4.1.1",
+        "@smithy/md5-js": "^4.1.1",
+        "@smithy/middleware-content-length": "^4.1.1",
+        "@smithy/middleware-endpoint": "^4.2.5",
+        "@smithy/middleware-retry": "^4.3.1",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-body-length-node": "^4.1.0",
+        "@smithy/util-defaults-mode-browser": "^4.1.5",
+        "@smithy/util-defaults-mode-node": "^4.1.5",
+        "@smithy/util-endpoints": "^3.1.2",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.2",
+        "@smithy/util-stream": "^4.3.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "@smithy/util-waiter": "^4.1.1",
+        "@smithy/uuid": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.899.0.tgz",
+      "integrity": "sha512-EKz/iiVDv2OC8/3ONcXG3+rhphx9Heh7KXQdsZzsAXGVn6mWtrHQLrWjgONckmK4LrD07y4+5WlJlGkMxSMA5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/middleware-host-header": "3.893.0",
+        "@aws-sdk/middleware-logger": "3.893.0",
+        "@aws-sdk/middleware-recursion-detection": "3.893.0",
+        "@aws-sdk/middleware-user-agent": "3.899.0",
+        "@aws-sdk/region-config-resolver": "3.893.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-endpoints": "3.895.0",
+        "@aws-sdk/util-user-agent-browser": "3.893.0",
+        "@aws-sdk/util-user-agent-node": "3.899.0",
+        "@smithy/config-resolver": "^4.2.2",
+        "@smithy/core": "^3.13.0",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/hash-node": "^4.1.1",
+        "@smithy/invalid-dependency": "^4.1.1",
+        "@smithy/middleware-content-length": "^4.1.1",
+        "@smithy/middleware-endpoint": "^4.2.5",
+        "@smithy/middleware-retry": "^4.3.1",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-body-length-node": "^4.1.0",
+        "@smithy/util-defaults-mode-browser": "^4.1.5",
+        "@smithy/util-defaults-mode-node": "^4.1.5",
+        "@smithy/util-endpoints": "^3.1.2",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.899.0.tgz",
+      "integrity": "sha512-Enp5Zw37xaRlnscyaelaUZNxVqyE3CTS8gjahFbW2bbzVtRD2itHBVgq8A3lvKiFb7Feoxa71aTe0fQ1I6AhQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/xml-builder": "3.894.0",
+        "@smithy/core": "^3.13.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/signature-v4": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.899.0.tgz",
+      "integrity": "sha512-wXQ//KQ751EFhUbdfoL/e2ZDaM8l2Cff+hVwFcj32yiZyeCMhnoLRMQk2euAaUOugqPY5V5qesFbHhISbIedtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.899.0.tgz",
+      "integrity": "sha512-/rRHyJFdnPrupjt/1q/PxaO6O26HFsguVUJSUeMeGUWLy0W8OC3slLFDNh89CgTqnplCyt1aLFMCagRM20HjNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-stream": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.899.0.tgz",
+      "integrity": "sha512-B8oFNFTDV0j1yiJiqzkC2ybml+theNnmsLrTLBhJbnBLWkxEcmVGKVIMnATW9BUCBhHmEtDiogdNIzSwP8tbMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/credential-provider-env": "3.899.0",
+        "@aws-sdk/credential-provider-http": "3.899.0",
+        "@aws-sdk/credential-provider-process": "3.899.0",
+        "@aws-sdk/credential-provider-sso": "3.899.0",
+        "@aws-sdk/credential-provider-web-identity": "3.899.0",
+        "@aws-sdk/nested-clients": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/credential-provider-imds": "^4.1.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.899.0.tgz",
+      "integrity": "sha512-nHBnZ2ZCOqTGJ2A9xpVj8iK6+WV+j0JNv3XGEkIuL4mqtGEPJlEex/0mD/hqc1VF8wZzojji2OQ3892m1mUOSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.899.0",
+        "@aws-sdk/credential-provider-http": "3.899.0",
+        "@aws-sdk/credential-provider-ini": "3.899.0",
+        "@aws-sdk/credential-provider-process": "3.899.0",
+        "@aws-sdk/credential-provider-sso": "3.899.0",
+        "@aws-sdk/credential-provider-web-identity": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/credential-provider-imds": "^4.1.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.899.0.tgz",
+      "integrity": "sha512-1PWSejKcJQUKBNPIqSHlEW4w8vSjmb+3kNJqCinJybjp5uP5BJgBp6QNcb8Nv30VBM0bn3ajVd76LCq4ZshQAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.899.0.tgz",
+      "integrity": "sha512-URlMbo74CAhIGrhzEP2fw5F5Tt6MRUctA8aa88MomlEHCEbJDsMD3nh6qoXxwR3LyvEBFmCWOZ/1TWmAjMsSdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.899.0",
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/token-providers": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.899.0.tgz",
+      "integrity": "sha512-UEn5o5FMcbeFPRRkJI6VCrgdyR9qsLlGA7+AKCYuYADsKbvJGIIQk6A2oD82vIVvLYD3TtbTLDLsF7haF9mpbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/nested-clients": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.893.0.tgz",
+      "integrity": "sha512-H+wMAoFC73T7M54OFIezdHXR9/lH8TZ3Cx1C3MEBb2ctlzQrVCd8LX8zmOtcGYC8plrRwV+8rNPe0FMqecLRew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-arn-parser": "3.893.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-config-provider": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.893.0.tgz",
+      "integrity": "sha512-PEZkvD6k0X9sacHkvkVF4t2QyQEAzd35OJ2bIrjWCfc862TwukMMJ1KErRmQ1WqKXHKF4L0ed5vtWaO/8jVLNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.899.0.tgz",
+      "integrity": "sha512-Hn2nyE+08/z+etssu++1W/kN9lCMAsLeg505mMcyrPs9Ex2XMl8ho/nYKBp5EjjfU8quqfP8O4NYt4KRy9OEaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/is-array-buffer": "^4.1.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-stream": "^4.3.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.893.0.tgz",
+      "integrity": "sha512-qL5xYRt80ahDfj9nDYLhpCNkDinEXvjLe/Qen/Y/u12+djrR2MB4DRa6mzBCkLkdXDtf0WAoW2EZsNCfGrmOEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.893.0.tgz",
+      "integrity": "sha512-MlbBc7Ttb1ekbeeeFBU4DeEZOLb5s0Vl4IokvO17g6yJdLk4dnvZro9zdXl3e7NXK+kFxHRBFZe55p/42mVgDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.893.0.tgz",
+      "integrity": "sha512-ZqzMecjju5zkBquSIfVfCORI/3Mge21nUY4nWaGQy+NUXehqCGG4W7AiVpiHGOcY2cGJa7xeEkYcr2E2U9U0AA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.893.0.tgz",
+      "integrity": "sha512-H7Zotd9zUHQAr/wr3bcWHULYhEeoQrF54artgsoUGIf/9emv6LzY89QUccKIxYd6oHKNTrTyXm9F0ZZrzXNxlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@aws/lambda-invoke-store": "^0.0.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.899.0.tgz",
+      "integrity": "sha512-/3/EIRSwQ5CNOSTHx96gVGzzmTe46OxcPG5FTgM6i9ZD+K/Q3J/UPGFL5DPzct5fXiSLvD1cGQitWHStVDjOVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-arn-parser": "3.893.0",
+        "@smithy/core": "^3.13.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/signature-v4": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-config-provider": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-stream": "^4.3.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.893.0.tgz",
+      "integrity": "sha512-e4ccCiAnczv9mMPheKjgKxZQN473mcup+3DPLVNnIw5GRbQoDqPSB70nUzfORKZvM7ar7xLMPxNR8qQgo1C8Rg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.899.0.tgz",
+      "integrity": "sha512-6EsVCC9j1VIyVyLOg+HyO3z9L+c0PEwMiHe3kuocoMf8nkfjSzJfIl6zAtgAXWgP5MKvusTP2SUbS9ezEEHZ+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-endpoints": "3.895.0",
+        "@smithy/core": "^3.13.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.899.0.tgz",
+      "integrity": "sha512-ySXXsFO0RH28VISEqvCuPZ78VAkK45/+OCIJgPvYpcCX9CVs70XSvMPXDI46I49mudJ1s4H3IUKccYSEtA+jaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/middleware-host-header": "3.893.0",
+        "@aws-sdk/middleware-logger": "3.893.0",
+        "@aws-sdk/middleware-recursion-detection": "3.893.0",
+        "@aws-sdk/middleware-user-agent": "3.899.0",
+        "@aws-sdk/region-config-resolver": "3.893.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-endpoints": "3.895.0",
+        "@aws-sdk/util-user-agent-browser": "3.893.0",
+        "@aws-sdk/util-user-agent-node": "3.899.0",
+        "@smithy/config-resolver": "^4.2.2",
+        "@smithy/core": "^3.13.0",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/hash-node": "^4.1.1",
+        "@smithy/invalid-dependency": "^4.1.1",
+        "@smithy/middleware-content-length": "^4.1.1",
+        "@smithy/middleware-endpoint": "^4.2.5",
+        "@smithy/middleware-retry": "^4.3.1",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-body-length-node": "^4.1.0",
+        "@smithy/util-defaults-mode-browser": "^4.1.5",
+        "@smithy/util-defaults-mode-node": "^4.1.5",
+        "@smithy/util-endpoints": "^3.1.2",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.893.0.tgz",
+      "integrity": "sha512-/cJvh3Zsa+Of0Zbg7vl9wp/kZtdb40yk/2+XcroAMVPO9hPvmS9r/UOm6tO7FeX4TtkRFwWaQJiTZTgSdsPY+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-config-provider": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.899.0.tgz",
+      "integrity": "sha512-wV51Jogxhd7dI4Q2Y1ASbkwTsRT3G8uwWFDCwl+WaErOQAzofKlV6nFJQlfgjMk4iEn2gFOIWqJ8fMTGShRK/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/signature-v4": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.899.0.tgz",
+      "integrity": "sha512-Ovu1nWr8HafYa/7DaUvvPnzM/yDUGDBqaiS7rRzv++F5VwyFY37+z/mHhvRnr+PbNWo8uf22a121SNue5uwP2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/nested-clients": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.893.0.tgz",
+      "integrity": "sha512-Aht1nn5SnA0N+Tjv0dzhAY7CQbxVtmq1bBR6xI0MhG7p2XYVh1wXuKTzrldEvQWwA3odOYunAfT9aBiKZx9qIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
+      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.895.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.895.0.tgz",
+      "integrity": "sha512-MhxBvWbwxmKknuggO2NeMwOVkHOYL98pZ+1ZRI5YwckoCL3AvISMnPJgfN60ww6AIXHGpkp+HhpFdKOe8RHSEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-endpoints": "^3.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.893.0.tgz",
+      "integrity": "sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.893.0.tgz",
+      "integrity": "sha512-PE9NtbDBW6Kgl1bG6A5fF3EPo168tnkj8TgMcT0sg4xYBWsBpq0bpJZRh+Jm5Bkwiw9IgTCLjEU7mR6xWaMB9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/types": "^4.5.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.899.0.tgz",
+      "integrity": "sha512-CiP0UAVQWLg2+8yciUBzVLaK5Fr7jBQ7wVu+p/O2+nlCOD3E3vtL1KZ1qX/d3OVpVSVaMAdZ9nbyewGV9hvjjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.894.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.894.0.tgz",
+      "integrity": "sha512-E6EAMc9dT1a2DOdo4zyOf3fp5+NJ2wI+mcm7RaW1baFIWDwcb99PpvWoV7YEiK7oaBDshuOEGWKUSYXdW+JYgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.0.1.tgz",
+      "integrity": "sha512-ORHRQ2tmvnBXc8t/X9Z8IcSbBA4xTLKuN873FopzklHMeqBst7YG0d+AX97inkvDX+NChYtSr+qGfcqGFaI8Zw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.11.3.tgz",
+      "integrity": "sha512-p3kf5eV49CJiRTfhtutUCeivSyQ/l2JlKodW1ZquRwwvlOWmG9+6jFShX6x8rUiYhnP6wKI96rgN/SXMy5e5aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.16",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.1.tgz",
+      "integrity": "sha512-5cnX+tASiPCqCWtFcFslxBVUaCetB0thvM/JyavhbXInP1HJIEU+Qv/zMrnuwSsX3yWH2lVXNJZeDK3EiP4HHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.1"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+      "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.16",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1.tgz",
+      "integrity": "sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.1.1.tgz",
+      "integrity": "sha512-vkzula+IwRvPR6oKQhMYioM3A/oX/lFCZiwuxkQbRhqJS2S4YRY2k7k/SyR2jMf3607HLtbEwlRxi0ndXHMjRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.1.0.tgz",
+      "integrity": "sha512-a36AtR7Q7XOhRPt6F/7HENmTWcB8kN7mDJcOFM/+FuKO6x88w8MQJfYCufMWh4fGyVkPjUh3Rrz/dnqFQdo6OQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.1.0.tgz",
+      "integrity": "sha512-Bnv0B3nSlfB2mPO0WgM49I/prl7+kamF042rrf3ezJ3Z4C7csPYvyYgZfXTGXwXfj1mAwDWjE/ybIf49PzFzvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.2.2.tgz",
+      "integrity": "sha512-IT6MatgBWagLybZl1xQcURXRICvqz1z3APSCAI9IqdvfCkrA7RaQIEfgC6G/KvfxnDfQUDqFV+ZlixcuFznGBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-config-provider": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.13.0.tgz",
+      "integrity": "sha512-BI6ALLPOKnPOU1Cjkc+1TPhOlP3JXSR/UH14JmnaLq41t3ma+IjuXrKfhycVjr5IQ0XxRh2NnQo3olp+eCVrGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-stream": "^4.3.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "@smithy/uuid": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.1.2.tgz",
+      "integrity": "sha512-JlYNq8TShnqCLg0h+afqe2wLAwZpuoSgOyzhYvTgbiKBWRov+uUve+vrZEQO6lkdLOWPh7gK5dtb9dS+KGendg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.1.1.tgz",
+      "integrity": "sha512-PwkQw1hZwHTQB6X5hSUWz2OSeuj5Z6enWuAqke7DgWoP3t6vg3ktPpqPz3Erkn6w+tmsl8Oss6nrgyezoea2Iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-hex-encoding": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.1.1.tgz",
+      "integrity": "sha512-Q9QWdAzRaIuVkefupRPRFAasaG/droBqn1feiMnmLa+LLEUG45pqX1+FurHFmlqiCfobB3nUlgoJfeXZsr7MPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.2.1.tgz",
+      "integrity": "sha512-oSUkF9zDN9zcOUBMtxp8RewJlh71E9NoHWU8jE3hU9JMYCsmW4assVTpgic/iS3/dM317j6hO5x18cc3XrfvEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.1.1.tgz",
+      "integrity": "sha512-tn6vulwf/ScY0vjhzptSJuDJJqlhNtUjkxJ4wiv9E3SPoEqTEKbaq6bfqRO7nvhTG29ALICRcvfFheOUPl8KNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.1.1.tgz",
+      "integrity": "sha512-uLOAiM/Dmgh2CbEXQx+6/ssK7fbzFhd+LjdyFxXid5ZBCbLHTFHLdD/QbXw5aEDsLxQhgzDxLLsZhsftAYwHJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.2.1.tgz",
+      "integrity": "sha512-5/3wxKNtV3wO/hk1is+CZUhL8a1yy/U+9u9LKQ9kZTkMsHaQjJhc3stFfiujtMnkITjzWfndGA2f7g9Uh9vKng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/querystring-builder": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-base64": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.1.1.tgz",
+      "integrity": "sha512-avAtk++s1e/1VODf+rg7c9R2pB5G9y8yaJaGY4lPZI2+UIqVyuSDMikWjeWfBVmFZ3O7NpDxBbUCyGhThVUKWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.1.0",
+        "@smithy/chunked-blob-reader-native": "^4.1.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.1.1.tgz",
+      "integrity": "sha512-H9DIU9WBLhYrvPs9v4sYvnZ1PiAI0oc8CgNQUJ1rpN3pP7QADbTOUjchI2FB764Ub0DstH5xbTqcMJu1pnVqxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-buffer-from": "^4.1.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.1.1.tgz",
+      "integrity": "sha512-3ztT4pV0Moazs3JAYFdfKk11kYFDo4b/3R3+xVjIm6wY9YpJf+xfz+ocEnNKcWAdcmSMqi168i2EMaKmJHbJMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.1.1.tgz",
+      "integrity": "sha512-1AqLyFlfrrDkyES8uhINRlJXmHA2FkG+3DY8X+rmLSqmFwk3DJnvhyGzyByPyewh2jbmV+TYQBEfngQax8IFGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.1.0.tgz",
+      "integrity": "sha512-ePTYUOV54wMogio+he4pBybe8fwg4sDvEVDBU8ZlHOZXbXK3/C0XfJgUCu6qAZcawv05ZhZzODGUerFBPsPUDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.1.1.tgz",
+      "integrity": "sha512-MvWXKK743BuHjr/hnWuT6uStdKEaoqxHAQUvbKJPPZM5ZojTNFI5D+47BoQfBE5RgGlRRty05EbWA+NXDv+hIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.1.1.tgz",
+      "integrity": "sha512-9wlfBBgTsRvC2JxLJxv4xDGNBrZuio3AgSl0lSFX7fneW2cGskXTYpFxCdRYD2+5yzmsiTuaAJD1Wp7gWt9y9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.2.5.tgz",
+      "integrity": "sha512-DdOIpssQ5LFev7hV6GX9TMBW5ChTsQBxqgNW1ZGtJNSAi5ksd5klwPwwMY0ejejfEzwXXGqxgVO3cpaod4veiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.13.0",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-middleware": "^4.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.3.1.tgz",
+      "integrity": "sha512-aH2bD1bzb6FB04XBhXA5mgedEZPKx3tD/qBuYCAKt5iieWvWO1Y2j++J9uLqOndXb9Pf/83Xka/YjSnMbcPchA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/service-error-classification": "^4.1.2",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.2",
+        "@smithy/uuid": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.1.1.tgz",
+      "integrity": "sha512-lh48uQdbCoj619kRouev5XbWhCwRKLmphAif16c4J6JgJ4uXjub1PI6RL38d3BLliUvSso6klyB/LTNpWSNIyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.1.1.tgz",
+      "integrity": "sha512-ygRnniqNcDhHzs6QAPIdia26M7e7z9gpkIMUe/pK0RsrQ7i5MblwxY8078/QCnGq6AmlUUWgljK2HlelsKIb/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.2.2.tgz",
+      "integrity": "sha512-SYGTKyPvyCfEzIN5rD8q/bYaOPZprYUPD2f5g9M7OjaYupWOoQFYJ5ho+0wvxIRf471i2SR4GoiZ2r94Jq9h6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.2.1.tgz",
+      "integrity": "sha512-REyybygHlxo3TJICPF89N2pMQSf+p+tBJqpVe1+77Cfi9HBPReNjTgtZ1Vg73exq24vkqJskKDpfF74reXjxfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/querystring-builder": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.1.1.tgz",
+      "integrity": "sha512-gm3ZS7DHxUbzC2wr8MUCsAabyiXY0gaj3ROWnhSx/9sPMc6eYLMM4rX81w1zsMaObj2Lq3PZtNCC1J6lpEY7zg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.2.1.tgz",
+      "integrity": "sha512-T8SlkLYCwfT/6m33SIU/JOVGNwoelkrvGjFKDSDtVvAXj/9gOT78JVJEas5a+ETjOu4SVvpCstKgd0PxSu/aHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.1.1.tgz",
+      "integrity": "sha512-J9b55bfimP4z/Jg1gNo+AT84hr90p716/nvxDkPGCD4W70MPms0h8KF50RDRgBGZeL83/u59DWNqJv6tEP/DHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-uri-escape": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.1.1.tgz",
+      "integrity": "sha512-63TEp92YFz0oQ7Pj9IuI3IgnprP92LrZtRAkE3c6wLWJxfy/yOPRt39IOKerVr0JS770olzl0kGafXlAXZ1vng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.1.2.tgz",
+      "integrity": "sha512-Kqd8wyfmBWHZNppZSMfrQFpc3M9Y/kjyN8n8P4DqJJtuwgK1H914R471HTw7+RL+T7+kI1f1gOnL7Vb5z9+NgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.2.0.tgz",
+      "integrity": "sha512-OQTfmIEp2LLuWdxa8nEEPhZmiOREO6bcB6pjs0AySf4yiZhl6kMOfqmcwcY8BaBPX+0Tb+tG7/Ia/6mwpoZ7Pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.2.1.tgz",
+      "integrity": "sha512-M9rZhWQLjlQVCCR37cSjHfhriGRN+FQ8UfgrYNufv66TJgk+acaggShl3KS5U/ssxivvZLlnj7QH2CUOKlxPyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.1.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-hex-encoding": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-uri-escape": "^4.1.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.6.5.tgz",
+      "integrity": "sha512-6J2hhuWu7EjnvLBIGltPCqzNswL1cW/AkaZx6i56qLsQ0ix17IAhmDD9aMmL+6CN9nCJODOXpBTCQS6iKAA7/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.13.0",
+        "@smithy/middleware-endpoint": "^4.2.5",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-stream": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-RkUpIOsVlAwUIZXO1dsz8Zm+N72LClFfsNqf173catVlvRZiwPy0x2u0JLEA4byreOPKDZPGjmPDylMoP8ZJRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.1.1.tgz",
+      "integrity": "sha512-bx32FUpkhcaKlEoOMbScvc93isaSiRM75pQ5IgIBaMkT7qMlIibpPRONyx/0CvrXHzJLpOn/u6YiDX2hcvs7Dg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.1.0.tgz",
+      "integrity": "sha512-RUGd4wNb8GeW7xk+AY5ghGnIwM96V0l2uzvs/uVHf+tIuVX2WSvynk5CxNoBCsM2rQRSZElAo9rt3G5mJ/gktQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.1.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.1.0.tgz",
+      "integrity": "sha512-V2E2Iez+bo6bUMOTENPr6eEmepdY8Hbs+Uc1vkDKgKNA/brTJqOW/ai3JO1BGj9GbCeLqw90pbbH7HFQyFotGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.1.0.tgz",
+      "integrity": "sha512-BOI5dYjheZdgR9XiEM3HJcEMCXSoqbzu7CzIgYrx0UtmvtC3tC2iDGpJLsSRFffUpy8ymsg2ARMP5fR8mtuUQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.1.0.tgz",
+      "integrity": "sha512-N6yXcjfe/E+xKEccWEKzK6M+crMrlwaCepKja0pNnlSkm6SjAeLKKA++er5Ba0I17gvKfN/ThV+ZOx/CntKTVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.1.0.tgz",
+      "integrity": "sha512-swXz2vMjrP1ZusZWVTB/ai5gK+J8U0BWvP10v9fpcFvg+Xi/87LHvHfst2IgCs1i0v4qFZfGwCmeD/KNCdJZbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.1.5.tgz",
+      "integrity": "sha512-FGBhlmFZVSRto816l6IwrmDcQ9pUYX6ikdR1mmAhdtSS1m77FgADukbQg7F7gurXfAvloxE/pgsrb7SGja6FQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.1.5.tgz",
+      "integrity": "sha512-Gwj8KLgJ/+MHYjVubJF0EELEh9/Ir7z7DFqyYlwgmp4J37KE+5vz6b3pWUnSt53tIe5FjDfVjDmHGYKjwIvW0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.2.2",
+        "@smithy/credential-provider-imds": "^4.1.2",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.1.2.tgz",
+      "integrity": "sha512-+AJsaaEGb5ySvf1SKMRrPZdYHRYSzMkCoK16jWnIMpREAnflVspMIDeCVSZJuj+5muZfgGpNpijE3mUNtjv01Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.1.0.tgz",
+      "integrity": "sha512-1LcueNN5GYC4tr8mo14yVYbh/Ur8jHhWOxniZXii+1+ePiIbsLZ5fEI0QQGtbRRP5mOhmooos+rLmVASGGoq5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.1.1.tgz",
+      "integrity": "sha512-CGmZ72mL29VMfESz7S6dekqzCh8ZISj3B+w0g1hZFXaOjGTVaSqfAEFAq8EGp8fUL+Q2l8aqNmt8U1tglTikeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.1.2.tgz",
+      "integrity": "sha512-NCgr1d0/EdeP6U5PSZ9Uv5SMR5XRRYoVr1kRVtKZxWL3tixEL3UatrPIMFZSKwHlCcp2zPLDvMubVDULRqeunA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.1.2",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.3.2.tgz",
+      "integrity": "sha512-Ka+FA2UCC/Q1dEqUanCdpqwxOFdf5Dg2VXtPtB1qxLcSGh5C1HdzklIt18xL504Wiy9nNUKwDMRTVCbKGoK69g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-buffer-from": "^4.1.0",
+        "@smithy/util-hex-encoding": "^4.1.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.1.0.tgz",
+      "integrity": "sha512-b0EFQkq35K5NHUYxU72JuoheM6+pytEVUGlTwiFxWFpmddA+Bpz3LgsPRIpBk8lnPE47yT7AF2Egc3jVnKLuPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.1.0.tgz",
+      "integrity": "sha512-mEu1/UIXAdNYuBcyEPbjScKi/+MQVXNIuY/7Cm5XLIWe319kDrT5SizBE95jqtmEXoDbGoZxKLCMttdZdqTZKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.1.1.tgz",
+      "integrity": "sha512-PJBmyayrlfxM7nbqjomF4YcT1sApQwZio0NHSsT0EzhJqljRmvhzqZua43TyEs80nJk2Cn2FGPg/N8phH6KeCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.0.0.tgz",
+      "integrity": "sha512-OlA/yZHh0ekYFnbUkmYBDQPE6fGfdrvgz39ktp8Xf+FA6BfxLejPTMDOG0Nfk5/rDySAz1dRbFf24zaAFYVXlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.0.tgz",
+      "integrity": "sha512-F1CBxgqwOMc4GKJ7eY22hWhBVQuMYTtqI8L0FcszYcpYX0fzfDGpez22Xau8Mgm7O9fI+zA/TYIdq3tGWfweBA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.13.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@videojs/vhs-utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.1.1.tgz",
+      "integrity": "sha512-5iLX6sR2ownbv4Mtejw6Ax+naosGvoT9kY+gcuHzANyUZZ+4NpeNdKMUhb6ag0acYej1Y7cmr/F2+4PrggMiVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "global": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
+      "integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
+      "license": "MIT"
+    },
+    "node_modules/bowser": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.1.tgz",
+      "integrity": "sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==",
+      "license": "MIT"
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.26",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.26.tgz",
+      "integrity": "sha512-xpmPviHjIJ6dFu1eNwNDIGQ3N6qmPUUYFVAx/YZ64h7ZgPkTcKjnciD8bZe8Vbeji7yS5uYljyciunpq0J5NSw==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.22.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.22.1.tgz",
+      "integrity": "sha512-3k+Kisd/v570Jr68A1kNs7qVhNehDwDJAPe4DZ2Syt+/zobf9zEcuYFvsfIaAOgCa0BiHMfOOKQY4eYINl0z7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/builders": "^1.11.2",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.1",
+        "@discordjs/rest": "^2.6.0",
+        "@discordjs/util": "^1.1.1",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.16",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "license": "MIT",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "license": "MIT"
+    },
+    "node_modules/iso-datestring-validator": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/iso-datestring-validator/-/iso-datestring-validator-2.2.2.tgz",
+      "integrity": "sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT"
+    },
+    "node_modules/m3u8-parser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-7.2.0.tgz",
+      "integrity": "sha512-CRatFqpjVtMiMaKXxNvuI3I++vUumIXVVT/JpCpdU/FynV/ceVw1qpPyyBNindL+JlPMSesx+WX1QJaZEJSaMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^4.1.1",
+        "global": "^4.4.0"
+      }
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
+      "integrity": "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA==",
+      "license": "MIT"
+    },
+    "node_modules/min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "dependencies": {
+        "dom-walk": "^0.1.0"
+      }
+    },
+    "node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "license": "(Apache-2.0 AND MIT)"
+    },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/tlds": {
+      "version": "1.260.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.260.0.tgz",
+      "integrity": "sha512-78+28EWBhCEE7qlyaHA9OR3IPvbCLiDh3Ckla593TksfFc9vfTsgvH7eS+dr3o9qr31gwGbogcI16yN91PoRjQ==",
+      "license": "MIT",
+      "bin": {
+        "tlds": "bin.js"
+      }
+    },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/uint8arrays": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
+      "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
+      "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "demo-progs",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@atproto/api": "^0.16.11",
+    "@aws-sdk/client-s3": "^3.899.0",
+    "discord.js": "^14.22.1",
+    "dotenv": "^17.2.3",
+    "m3u8-parser": "^7.2.0",
+    "pg": "^8.16.3"
+  }
+}

--- a/src/bluesky.js
+++ b/src/bluesky.js
@@ -1,0 +1,482 @@
+import { promises as fs, createWriteStream } from 'fs';
+import path from 'path';
+import { finished } from 'stream/promises';
+import { once } from 'node:events';
+import { createDecipheriv } from 'node:crypto';
+import { spawn } from 'node:child_process';
+import { AtpAgent } from '@atproto/api';
+import { Parser as M3U8Parser } from 'm3u8-parser';
+import { config } from './config.js';
+
+const BSKY_SERVICE = 'https://public.api.bsky.app';
+const agent = new AtpAgent({ service: BSKY_SERVICE });
+
+const BLUESKY_POST_REGEX = /https?:\/\/(?:www\.)?bsky\.app\/profile\/([^\s/]+)\/post\/([A-Za-z0-9]+)/gi;
+
+export function extractBlueskyPostLinks(text) {
+  const matches = [];
+  if (!text) {
+    return matches;
+  }
+  let match;
+  while ((match = BLUESKY_POST_REGEX.exec(text)) !== null) {
+    const rawUrl = match[0].replace(/[)>.,!?]+$/, '');
+    matches.push({
+      url: rawUrl,
+      handle: match[1],
+      rkey: match[2],
+    });
+  }
+  return matches;
+}
+
+async function resolvePost(handle, rkey) {
+  const { data: identity } = await agent.resolveHandle({ handle });
+  const did = identity?.did;
+  if (!did) {
+    throw new Error(`Unable to resolve handle ${handle}`);
+  }
+  const uri = `at://${did}/app.bsky.feed.post/${rkey}`;
+  const { data } = await agent.api.app.bsky.feed.getPostThread({ uri });
+  if (!data?.thread?.post) {
+    throw new Error('Post not found or unavailable');
+  }
+  const post = data.thread.post;
+  const embed = post.embed ?? post.record?.embed;
+  const videoInfo = extractVideoInfo(embed, post.record?.embed);
+  if (!videoInfo) {
+    throw new Error('Post does not contain a downloadable video');
+  }
+  return {
+    post,
+    videoInfo,
+    uri,
+    author: post.author,
+    record: post.record,
+  };
+}
+
+function extractVideoInfo(viewEmbed, recordEmbed) {
+  const viewInfo = extractVideoFromEmbed(viewEmbed);
+  const recordInfo = extractVideoFromEmbed(recordEmbed);
+  if (viewInfo && recordInfo) {
+    return { ...recordInfo, ...viewInfo };
+  }
+  return viewInfo ?? recordInfo ?? null;
+}
+
+function extractVideoFromEmbed(embed) {
+  if (!embed) return null;
+  if (embed.$type === 'app.bsky.embed.recordWithMedia' && embed.media) {
+    return extractVideoFromEmbed(embed.media);
+  }
+  if (embed.$type === 'app.bsky.embed.video#view') {
+    return {
+      playlistUrl: embed.playlist,
+      cid: embed.cid,
+      aspectRatio: embed.aspectRatio,
+      thumbnail: embed.thumbnail,
+    };
+  }
+  if (embed.$type === 'app.bsky.embed.video' && embed.video?.ref?.$link) {
+    return {
+      blobCid: embed.video.ref.$link,
+      mimeType: embed.video.mimeType,
+      size: embed.video.size,
+    };
+  }
+  if (embed.video) {
+    return extractVideoFromEmbed(embed.video);
+  }
+  return null;
+}
+
+export async function fetchBlueskyVideo(postUrlOrMatch) {
+  const { handle, rkey } = typeof postUrlOrMatch === 'string'
+    ? parseBlueskyPostUrl(postUrlOrMatch)
+    : postUrlOrMatch;
+  if (!handle || !rkey) {
+    throw new Error('Invalid Bluesky post URL');
+  }
+  const { post, videoInfo, author, record } = await resolvePost(handle, rkey);
+  if (videoInfo?.size && videoInfo.size > config.maxUploadBytes) {
+    throw new Error(
+      `Video file is ${formatBytes(videoInfo.size)}, which exceeds the configured upload limit of ${formatBytes(config.maxUploadBytes)}.`
+    );
+  }
+  let downloadResult;
+  if (videoInfo?.playlistUrl) {
+    downloadResult = await downloadFromPlaylist(videoInfo.playlistUrl);
+  } else if (videoInfo?.blobCid) {
+    downloadResult = await downloadFromBlob(author?.did ?? record?.author?.did, videoInfo);
+  } else {
+    throw new Error('No downloadable source located for this video');
+  }
+  return {
+    ...downloadResult,
+    post,
+    author,
+    videoInfo,
+  };
+}
+
+function formatBytes(bytes) {
+  if (bytes === 0) return '0 B';
+  const units = ['B', 'KiB', 'MiB', 'GiB'];
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** exponent;
+  return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+}
+
+function parseBlueskyPostUrl(url) {
+  const cleaned = url.trim().replace(/[)>.,!?]+$/, '');
+  const match = /^https?:\/\/(?:www\.)?bsky\.app\/profile\/([^\s/]+)\/post\/([A-Za-z0-9]+)/i.exec(cleaned);
+  if (!match) {
+    return {};
+  }
+  return { handle: match[1], rkey: match[2], url: cleaned };
+}
+
+function detectPlaylistContainer(manifest) {
+  const hasInitSegments = manifest.segments?.some((segment) => segment.map?.uri);
+  if (hasInitSegments) {
+    return { type: 'fmp4', extension: 'mp4', mimeType: 'video/mp4' };
+  }
+  return { type: 'ts', extension: 'ts', mimeType: 'video/mp2t' };
+}
+
+function buildInitSegmentKey(map, resolvedRange) {
+  if (!map?.uri) {
+    return null;
+  }
+  if (!resolvedRange) {
+    return map.uri;
+  }
+  const offsetPart = resolvedRange.offset !== undefined ? resolvedRange.offset : '';
+  return `${map.uri}#${resolvedRange.length}@${offsetPart}`;
+}
+
+async function downloadFromPlaylist(playlistUrl) {
+  const masterContent = await fetchText(playlistUrl);
+  const masterParser = new M3U8Parser();
+  masterParser.push(masterContent);
+  masterParser.end();
+  const master = masterParser.manifest;
+  if (!master.playlists?.length) {
+    throw new Error('Playlist does not contain any variants');
+  }
+  const sorted = [...master.playlists].sort((a, b) => (b.attributes?.BANDWIDTH ?? 0) - (a.attributes?.BANDWIDTH ?? 0));
+  const selected = sorted[0];
+  const variantUrl = new URL(selected.uri, playlistUrl).toString();
+  const variantContent = await fetchText(variantUrl);
+  const variantParser = new M3U8Parser();
+  variantParser.push(variantContent);
+  variantParser.end();
+  const { segments } = variantParser.manifest;
+  if (!segments?.length) {
+    throw new Error('Variant playlist is empty');
+  }
+  const tempDir = await prepareTempDir();
+  const container = detectPlaylistContainer(variantParser.manifest);
+  const fileName = `video.${container.extension}`;
+  const filePath = path.join(tempDir, fileName);
+  const fileStream = createWriteStream(filePath);
+  let activeInitKey = null;
+  const keyCache = new Map();
+  const byteRangeState = new Map();
+  const mapByteRangeState = new Map();
+  const baseSequence = variantParser.manifest.mediaSequence ?? 0;
+  try {
+    for (let index = 0; index < segments.length; index += 1) {
+      const segment = segments[index];
+      if (segment.discontinuity) {
+        activeInitKey = null;
+        byteRangeState.clear();
+        mapByteRangeState.clear();
+      }
+
+      if (segment.map?.uri) {
+        const initRange = resolveByteRange(segment.map.byterange, segment.map.uri, mapByteRangeState);
+        const mapKey = buildInitSegmentKey(segment.map, initRange);
+        if (activeInitKey !== mapKey) {
+          const initUrl = new URL(segment.map.uri, variantUrl).toString();
+          const initBuffer = await fetchBuffer(initUrl, `initialization segment ${segment.map.uri}`, initRange);
+          await writeBufferToStream(fileStream, initBuffer);
+          activeInitKey = mapKey;
+        }
+      }
+
+      const segmentUrl = new URL(segment.uri, variantUrl).toString();
+      const range = resolveByteRange(segment.byterange, segment.uri, byteRangeState);
+      let segmentBuffer = await fetchBuffer(segmentUrl, `segment ${segment.uri}`, range);
+      const keyInfo = segment.key ?? null;
+      if (keyInfo && keyInfo.method && keyInfo.method !== 'NONE') {
+        const method = keyInfo.method.toUpperCase();
+        if (method !== 'AES-128') {
+          throw new Error(`Unsupported HLS encryption method: ${keyInfo.method}`);
+        }
+
+        if (!keyInfo.uri) {
+          throw new Error('HLS encryption key is missing a URI');
+        }
+
+        const keyUrl = new URL(keyInfo.uri, variantUrl).toString();
+        let keyBuffer = keyCache.get(keyUrl);
+        if (!keyBuffer) {
+          keyBuffer = await fetchBuffer(keyUrl, `encryption key ${keyInfo.uri}`);
+          if (keyBuffer.length !== 16) {
+            throw new Error(`Unexpected HLS encryption key length for ${keyInfo.uri}`);
+          }
+          keyCache.set(keyUrl, keyBuffer);
+        }
+
+        const sequenceNumber = segment.mediaSequenceNumber ?? baseSequence + index;
+        const iv = deriveInitializationVector(keyInfo.iv, sequenceNumber);
+        const decipher = createDecipheriv('aes-128-cbc', keyBuffer, iv);
+        segmentBuffer = Buffer.concat([decipher.update(segmentBuffer), decipher.final()]);
+      }
+
+      await writeBufferToStream(fileStream, segmentBuffer);
+    }
+  } catch (error) {
+    fileStream.destroy(error);
+    throw error;
+  }
+  fileStream.end();
+  await finished(fileStream);
+  let finalFilePath = filePath;
+  let finalFileName = fileName;
+  let finalMimeType = container.mimeType;
+
+  if (container.type === 'ts') {
+    const remuxed = await remuxTransportStream(tempDir, filePath, fileName);
+    finalFilePath = remuxed.filePath;
+    finalFileName = remuxed.fileName;
+    finalMimeType = remuxed.mimeType;
+  }
+
+  return {
+    filePath: finalFilePath,
+    fileName: finalFileName,
+    cleanupDir: tempDir,
+    mimeType: finalMimeType,
+  };
+}
+
+async function downloadFromBlob(did, videoInfo) {
+  if (!did || !videoInfo?.blobCid) {
+    throw new Error('Missing blob download information');
+  }
+  const blobUrl = `${BSKY_SERVICE}/xrpc/com.atproto.sync.getBlob?did=${encodeURIComponent(did)}&cid=${encodeURIComponent(videoInfo.blobCid)}`;
+  const response = await fetch(blobUrl);
+  if (!response.ok || !response.body) {
+    throw new Error('Failed to download video blob');
+  }
+  const tempDir = await prepareTempDir();
+  const extension = getExtensionFromMime(videoInfo.mimeType) ?? 'mp4';
+  const fileName = `video.${extension}`;
+  const filePath = path.join(tempDir, fileName);
+  const fileStream = createWriteStream(filePath);
+  try {
+    for await (const chunk of response.body) {
+      if (!fileStream.write(chunk)) {
+        await once(fileStream, 'drain');
+      }
+    }
+  } catch (error) {
+    fileStream.destroy(error);
+    throw error;
+  }
+  fileStream.end();
+  await finished(fileStream);
+  return {
+    filePath,
+    fileName,
+    cleanupDir: tempDir,
+    mimeType: videoInfo.mimeType ?? getMimeTypeFromExtension(extension),
+  };
+}
+
+function getExtensionFromMime(mimeType) {
+  if (!mimeType) return null;
+  if (mimeType.includes('mp4')) return 'mp4';
+  if (mimeType.includes('quicktime')) return 'mov';
+  if (mimeType.includes('webm')) return 'webm';
+  return null;
+}
+
+function getMimeTypeFromExtension(extension) {
+  switch (extension) {
+    case 'mp4':
+      return 'video/mp4';
+    case 'mov':
+      return 'video/quicktime';
+    case 'webm':
+      return 'video/webm';
+    case 'ts':
+      return 'video/mp2t';
+    default:
+      return undefined;
+  }
+}
+
+async function fetchText(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url} (${response.status})`);
+  }
+  return response.text();
+}
+
+async function fetchBuffer(url, label, range) {
+  const headers = {};
+  if (range) {
+    const start = range.offset ?? 0;
+    const end = start + range.length - 1;
+    headers.Range = `bytes=${start}-${end}`;
+  }
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`Failed to download ${label ?? url} (${response.status})`);
+  }
+  const arrayBuffer = await response.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}
+
+function resolveByteRange(range, uri, state) {
+  if (!range) {
+    if (state && uri) {
+      state.delete(uri);
+    }
+    return null;
+  }
+
+  const parsed = parseByteRange(range, uri);
+  if (parsed.offset === undefined) {
+    const previous = state?.get(uri) ?? 0;
+    parsed.offset = previous;
+  }
+
+  if (state && uri) {
+    state.set(uri, parsed.offset + parsed.length);
+  }
+
+  return parsed;
+}
+
+function parseByteRange(range, uri) {
+  if (typeof range === 'string') {
+    const [lengthString, offsetString] = range.split('@');
+    const length = Number(lengthString);
+    const offset = offsetString !== undefined ? Number(offsetString) : undefined;
+    validateByteRange(length, offset, uri);
+    return { length, offset };
+  }
+
+  const length = Number(range.length);
+  const offset = range.offset !== undefined ? Number(range.offset) : undefined;
+  validateByteRange(length, offset, uri);
+  return { length, offset };
+}
+
+function validateByteRange(length, offset, uri) {
+  if (!Number.isFinite(length) || length <= 0) {
+    throw new Error(`Invalid byte range length for ${uri ?? 'segment'}`);
+  }
+  if (offset !== undefined && (!Number.isFinite(offset) || offset < 0)) {
+    throw new Error(`Invalid byte range offset for ${uri ?? 'segment'}`);
+  }
+}
+
+async function writeBufferToStream(stream, buffer) {
+  if (!stream.write(buffer)) {
+    await once(stream, 'drain');
+  }
+}
+
+async function remuxTransportStream(tempDir, inputFilePath, inputFileName) {
+  const outputFileName = `${path.parse(inputFileName).name}.mp4`;
+  const outputFilePath = path.join(tempDir, outputFileName);
+  const args = [
+    '-hide_banner',
+    '-loglevel',
+    'error',
+    '-y',
+    '-i',
+    inputFilePath,
+    '-c',
+    'copy',
+    outputFilePath,
+  ];
+
+  try {
+    await runFfmpeg(args);
+  } catch (error) {
+    await fs.rm(outputFilePath, { force: true }).catch(() => {});
+    throw new Error(`Failed to convert transport stream to MP4: ${error.message}`, { cause: error });
+  }
+
+  await fs.rm(inputFilePath, { force: true }).catch(() => {});
+
+  return {
+    filePath: outputFilePath,
+    fileName: outputFileName,
+    mimeType: 'video/mp4',
+  };
+}
+
+function runFfmpeg(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(config.ffmpegPath, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+
+    if (child.stderr) {
+      child.stderr.setEncoding('utf8');
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk;
+      });
+    }
+
+    child.once('error', (error) => {
+      reject(error);
+    });
+
+    child.once('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        const error = new Error(`ffmpeg exited with code ${code}${stderr ? `: ${stderr.trim()}` : ''}`);
+        reject(error);
+      }
+    });
+  });
+}
+
+function deriveInitializationVector(ivString, sequenceNumber) {
+  if (ivString) {
+    const normalized = ivString.startsWith('0x') ? ivString.slice(2) : ivString;
+    return Buffer.from(normalized.padStart(32, '0'), 'hex');
+  }
+
+  const iv = Buffer.alloc(16);
+  // Use the media sequence number as the IV when none is provided, per HLS AES-128 spec.
+  const normalizedSequence = Number.isFinite(sequenceNumber)
+    ? Math.max(0, Math.floor(sequenceNumber))
+    : 0;
+  let value = BigInt(normalizedSequence);
+  for (let index = 15; index >= 0 && value > 0n; index -= 1) {
+    iv[index] = Number(value & 0xffn);
+    value >>= 8n;
+  }
+  return iv;
+}
+
+async function prepareTempDir() {
+  await fs.mkdir(config.downloadRoot, { recursive: true });
+  return fs.mkdtemp(path.join(config.downloadRoot, 'bsky-'));
+}
+
+export async function cleanupDownload(tempDir) {
+  if (!tempDir) return;
+  await fs.rm(tempDir, { recursive: true, force: true });
+}

--- a/src/bluesky.js
+++ b/src/bluesky.js
@@ -99,11 +99,6 @@ export async function fetchBlueskyVideo(postUrlOrMatch) {
     throw new Error('Invalid Bluesky post URL');
   }
   const { post, videoInfo, author, record } = await resolvePost(handle, rkey);
-  if (videoInfo?.size && videoInfo.size > config.maxUploadBytes) {
-    throw new Error(
-      `Video file is ${formatBytes(videoInfo.size)}, which exceeds the configured upload limit of ${formatBytes(config.maxUploadBytes)}.`
-    );
-  }
   let downloadResult;
   if (videoInfo?.playlistUrl) {
     downloadResult = await downloadFromPlaylist(videoInfo.playlistUrl);
@@ -118,14 +113,6 @@ export async function fetchBlueskyVideo(postUrlOrMatch) {
     author,
     videoInfo,
   };
-}
-
-function formatBytes(bytes) {
-  if (bytes === 0) return '0 B';
-  const units = ['B', 'KiB', 'MiB', 'GiB'];
-  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
-  const value = bytes / 1024 ** exponent;
-  return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
 }
 
 function parseBlueskyPostUrl(url) {
@@ -255,11 +242,14 @@ async function downloadFromPlaylist(playlistUrl) {
     finalMimeType = remuxed.mimeType;
   }
 
+  const { size } = await fs.stat(finalFilePath);
+
   return {
     filePath: finalFilePath,
     fileName: finalFileName,
     cleanupDir: tempDir,
     mimeType: finalMimeType,
+    fileSize: size,
   };
 }
 
@@ -289,11 +279,14 @@ async function downloadFromBlob(did, videoInfo) {
   }
   fileStream.end();
   await finished(fileStream);
+  const { size } = await fs.stat(filePath);
+
   return {
     filePath,
     fileName,
     cleanupDir: tempDir,
     mimeType: videoInfo.mimeType ?? getMimeTypeFromExtension(extension),
+    fileSize: size,
   };
 }
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -1,0 +1,200 @@
+import {
+  SlashCommandBuilder,
+  EmbedBuilder,
+  bold,
+  AttachmentBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} from 'discord.js';
+import { saveGuildSettings } from './database.js';
+import { guildSettingsCache } from './settingsCache.js';
+import { cleanupDownload, extractBlueskyPostLinks, fetchBlueskyVideo } from './bluesky.js';
+import { uploadToR2 } from './storage.js';
+
+export const commandDefinitions = [
+  new SlashCommandBuilder()
+    .setName('bluesky-listener')
+    .setDescription('Enable or disable automatic Bluesky video downloads for this server.')
+    .addBooleanOption((option) =>
+      option
+        .setName('enabled')
+        .setDescription('Enable automatic downloads when Bluesky links are posted.')
+        .setRequired(true)
+    )
+    .addBooleanOption((option) =>
+      option
+        .setName('silent')
+        .setDescription('Only post the video URL without embeds when downloads are posted.')
+        .setRequired(false)
+    ),
+  new SlashCommandBuilder()
+    .setName('bluesky-download')
+    .setDescription('Download a video from a specific Bluesky post.')
+    .addStringOption((option) =>
+      option
+        .setName('url')
+        .setDescription('The Bluesky post URL to download the video from.')
+        .setRequired(true)
+    )
+    .addBooleanOption((option) =>
+      option
+        .setName('silent')
+        .setDescription('Only return the video URL without embeds.')
+        .setRequired(false)
+    ),
+].map((builder) => builder.toJSON());
+
+export async function handleCommandInteraction(interaction) {
+  if (!interaction.inCachedGuild()) {
+    await interaction.reply({
+      content: 'This command can only be used within a server.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  if (interaction.commandName === 'bluesky-listener') {
+    await handleToggleCommand(interaction);
+    return;
+  }
+
+  if (interaction.commandName === 'bluesky-download') {
+    await handleDownloadCommand(interaction);
+    return;
+  }
+}
+
+async function handleToggleCommand(interaction) {
+  const enabled = interaction.options.getBoolean('enabled', true);
+  const silent = interaction.options.getBoolean('silent');
+  await interaction.deferReply({ ephemeral: true });
+  const updated = await saveGuildSettings(interaction.guildId, {
+    listenEnabled: enabled,
+    silentMode: silent ?? undefined,
+  });
+  guildSettingsCache.set(interaction.guildId, updated);
+  const embed = new EmbedBuilder()
+    .setTitle('Bluesky listener updated')
+    .setDescription(
+      `Automatic downloads are now ${enabled ? bold('enabled') : bold('disabled')} for this server.\n` +
+        `Silent mode is ${updated.silentMode ? bold('enabled') : bold('disabled')}.`
+    )
+    .setColor(enabled ? 0x2ecc71 : 0xe74c3c);
+  await interaction.editReply({ embeds: [embed] });
+}
+
+async function handleDownloadCommand(interaction) {
+  const url = interaction.options.getString('url', true);
+  const silent = interaction.options.getBoolean('silent') ?? false;
+  await interaction.deferReply({ ephemeral: false });
+  let download;
+  try {
+    download = await fetchBlueskyVideo(url);
+    const upload = await uploadToR2(download.filePath, {
+      fileName: download.fileName,
+      contentType: download.mimeType ?? download.videoInfo?.mimeType,
+    });
+    const response = buildMessagePayload({
+      download,
+      requestedBy: interaction.user.username,
+      postUrl: url,
+      videoUrl: upload.publicUrl,
+      silent,
+    });
+    await interaction.editReply(response);
+  } catch (error) {
+    await interaction.editReply({
+      embeds: [
+        new EmbedBuilder()
+          .setTitle('Unable to download video')
+          .setDescription(error.message ?? 'An unexpected error occurred.')
+          .setColor(0xe74c3c),
+      ],
+    });
+  } finally {
+    if (download?.cleanupDir) {
+      await cleanupDownload(download.cleanupDir);
+    }
+  }
+}
+
+export async function handlePotentialBlueskyLinks(message) {
+  if (!message.guild || message.author.bot) return;
+  const settings = await guildSettingsCache.get(message.guildId);
+  if (!settings.listenEnabled) return;
+
+  const links = extractBlueskyPostLinks(message.content);
+  if (!links.length) return;
+
+  for (const link of links) {
+    let download;
+    try {
+      download = await fetchBlueskyVideo(link);
+      const upload = await uploadToR2(download.filePath, {
+        fileName: download.fileName,
+        contentType: download.mimeType ?? download.videoInfo?.mimeType,
+      });
+      const payload = buildMessagePayload({
+        download,
+        requestedBy: message.author.username,
+        postUrl: link.url,
+        videoUrl: upload.publicUrl,
+        silent: settings.silentMode,
+      });
+      await message.channel.send(payload);
+    } catch (error) {
+      const embed = new EmbedBuilder()
+        .setTitle('Bluesky download failed')
+        .setDescription(error.message ?? 'An unexpected error occurred.')
+        .setColor(0xe67e22);
+      await message.channel.send({ embeds: [embed] });
+    } finally {
+      if (download?.cleanupDir) {
+        await cleanupDownload(download.cleanupDir);
+      }
+    }
+  }
+}
+
+function buildVideoEmbed(download, requestedBy, url) {
+  const { post, author } = download;
+  const embed = new EmbedBuilder()
+    .setTitle(`Video from ${author?.displayName ?? author?.handle ?? 'Bluesky'}`)
+    .setDescription(post?.record?.text ?? 'Video attachment')
+    .setURL(url)
+    .setColor(0x3498db)
+    .setTimestamp(new Date(post?.indexedAt ?? Date.now()));
+
+  if (download.videoInfo?.thumbnail) {
+    embed.setThumbnail(download.videoInfo.thumbnail);
+  }
+
+  if (requestedBy) {
+    embed.setFooter({ text: `Requested by ${requestedBy}` });
+  }
+
+  return embed;
+}
+
+function buildMessagePayload({ download, requestedBy, postUrl, videoUrl, silent }) {
+  const attachment = new AttachmentBuilder(download.filePath).setName(download.fileName);
+  const components = [
+    new ActionRowBuilder().addComponents(
+      new ButtonBuilder().setLabel('Download').setStyle(ButtonStyle.Link).setURL(videoUrl)
+    ),
+  ];
+
+  const base = {
+    files: [attachment],
+    components,
+    allowedMentions: { parse: [] },
+  };
+
+  if (silent) {
+    return base;
+  }
+
+  const embed = buildVideoEmbed(download, requestedBy, postUrl);
+  return { ...base, embeds: [embed] };
+}

--- a/src/commands.js
+++ b/src/commands.js
@@ -7,7 +7,7 @@ import {
   ButtonBuilder,
   ButtonStyle,
 } from 'discord.js';
-import { saveGuildSettings } from './database.js';
+import { saveGuildSettings, recordDownload } from './database.js';
 import { guildSettingsCache } from './settingsCache.js';
 import { cleanupDownload, extractBlueskyPostLinks, fetchBlueskyVideo } from './bluesky.js';
 import { uploadToR2 } from './storage.js';
@@ -115,6 +115,11 @@ async function handleDownloadCommand(interaction) {
       fileName: download.fileName,
       contentType: download.mimeType ?? download.videoInfo?.mimeType,
     });
+    await persistDownloadRecord({
+      userId: interaction.user.id,
+      blueskyUrl: url,
+      r2Url: upload.publicUrl,
+    });
     const attachFile = (download.fileSize ?? download.videoInfo?.size ?? 0) <= config.maxUploadBytes;
     const response = buildMessagePayload({
       download,
@@ -196,6 +201,11 @@ async function handleBulkDownloadCommand(interaction) {
         fileName: download.fileName,
         contentType: download.mimeType ?? download.videoInfo?.mimeType,
       });
+      await persistDownloadRecord({
+        userId: interaction.user.id,
+        blueskyUrl: link.url,
+        r2Url: upload.publicUrl,
+      });
       const attachFile = (download.fileSize ?? download.videoInfo?.size ?? 0) <= config.maxUploadBytes;
       const payload = buildMessagePayload({
         download,
@@ -252,6 +262,11 @@ export async function handlePotentialBlueskyLinks(message) {
       const upload = await uploadToR2(download.filePath, {
         fileName: download.fileName,
         contentType: download.mimeType ?? download.videoInfo?.mimeType,
+      });
+      await persistDownloadRecord({
+        userId: message.author.id,
+        blueskyUrl: link.url,
+        r2Url: upload.publicUrl,
       });
       const attachFile = (download.fileSize ?? download.videoInfo?.size ?? 0) <= config.maxUploadBytes;
       const payload = buildMessagePayload({
@@ -365,4 +380,12 @@ function truncateForField(text, maxLength = 256) {
     return text;
   }
   return `${text.slice(0, maxLength - 1)}…`;
+}
+
+async function persistDownloadRecord({ userId, blueskyUrl, r2Url }) {
+  try {
+    await recordDownload({ userId, blueskyUrl, r2Url });
+  } catch (error) {
+    console.error('Failed to record Bluesky download', error);
+  }
 }

--- a/src/commands.js
+++ b/src/commands.js
@@ -12,6 +12,8 @@ import { guildSettingsCache } from './settingsCache.js';
 import { cleanupDownload, extractBlueskyPostLinks, fetchBlueskyVideo } from './bluesky.js';
 import { uploadToR2 } from './storage.js';
 
+const MAX_BULK_LINKS = 10;
+
 export const commandDefinitions = [
   new SlashCommandBuilder()
     .setName('bluesky-listener')
@@ -43,6 +45,21 @@ export const commandDefinitions = [
         .setDescription('Only return the video URL without embeds.')
         .setRequired(false)
     ),
+  new SlashCommandBuilder()
+    .setName('bluesky-bulk')
+    .setDescription('Download multiple Bluesky videos with a single command.')
+    .addStringOption((option) =>
+      option
+        .setName('urls')
+        .setDescription('Comma separated Bluesky post URLs.')
+        .setRequired(true)
+    )
+    .addBooleanOption((option) =>
+      option
+        .setName('silent')
+        .setDescription('Only return the video URLs without embeds.')
+        .setRequired(false)
+    ),
 ].map((builder) => builder.toJSON());
 
 export async function handleCommandInteraction(interaction) {
@@ -62,6 +79,10 @@ export async function handleCommandInteraction(interaction) {
   if (interaction.commandName === 'bluesky-download') {
     await handleDownloadCommand(interaction);
     return;
+  }
+
+  if (interaction.commandName === 'bluesky-bulk') {
+    await handleBulkDownloadCommand(interaction);
   }
 }
 
@@ -115,6 +136,113 @@ async function handleDownloadCommand(interaction) {
   } finally {
     if (download?.cleanupDir) {
       await cleanupDownload(download.cleanupDir);
+    }
+  }
+}
+
+async function handleBulkDownloadCommand(interaction) {
+  const urlsText = interaction.options.getString('urls', true);
+  const silent = interaction.options.getBoolean('silent') ?? false;
+  const matches = extractBlueskyPostLinks(urlsText);
+  const uniqueLinks = [];
+  const seen = new Set();
+  for (const match of matches) {
+    if (!seen.has(match.url)) {
+      uniqueLinks.push(match);
+      seen.add(match.url);
+    }
+  }
+
+  if (!uniqueLinks.length) {
+    await interaction.reply({
+      embeds: [
+        new EmbedBuilder()
+          .setTitle('No Bluesky links found')
+          .setDescription('Provide a comma separated list of Bluesky post URLs to download.')
+          .setColor(0xe74c3c),
+      ],
+      ephemeral: true,
+    });
+    return;
+  }
+
+  if (uniqueLinks.length > MAX_BULK_LINKS) {
+    await interaction.reply({
+      embeds: [
+        new EmbedBuilder()
+          .setTitle('Too many links')
+          .setDescription(`Bulk downloads are limited to ${MAX_BULK_LINKS} posts at a time.`)
+          .setColor(0xe74c3c),
+      ],
+      ephemeral: true,
+    });
+    return;
+  }
+
+  await interaction.deferReply({ ephemeral: false });
+
+  const start = Date.now();
+  const failures = [];
+  let completed = 0;
+  let successes = 0;
+
+  await interaction.editReply({
+    embeds: [
+      buildBulkStatusEmbed({
+        total: uniqueLinks.length,
+        completed,
+        successes,
+        failures,
+        start,
+        silent,
+        done: false,
+      }),
+    ],
+  });
+
+  for (const link of uniqueLinks) {
+    let download;
+    try {
+      download = await fetchBlueskyVideo(link);
+      const upload = await uploadToR2(download.filePath, {
+        fileName: download.fileName,
+        contentType: download.mimeType ?? download.videoInfo?.mimeType,
+      });
+      const payload = buildMessagePayload({
+        download,
+        requestedBy: interaction.user.username,
+        postUrl: link.url,
+        videoUrl: upload.publicUrl,
+        silent,
+      });
+      await interaction.followUp(payload);
+      successes += 1;
+    } catch (error) {
+      failures.push({ url: link.url, message: error.message ?? 'An unexpected error occurred.' });
+      const errorEmbed = new EmbedBuilder()
+        .setTitle('Bluesky download failed')
+        .setDescription(`[Open post](${link.url})`)
+        .addFields({ name: 'Error', value: error.message ?? 'An unexpected error occurred.' })
+        .setColor(0xe67e22);
+      await interaction.followUp({ embeds: [errorEmbed] });
+    } finally {
+      completed += 1;
+      if (download?.cleanupDir) {
+        await cleanupDownload(download.cleanupDir);
+      }
+      await interaction.editReply({
+        embeds: [
+          buildBulkStatusEmbed({
+            total: uniqueLinks.length,
+            completed,
+            successes,
+            failures,
+            start,
+            silent,
+            done: completed === uniqueLinks.length,
+          }),
+        ],
+      });
     }
   }
 }
@@ -197,4 +325,38 @@ function buildMessagePayload({ download, requestedBy, postUrl, videoUrl, silent 
 
   const embed = buildVideoEmbed(download, requestedBy, postUrl);
   return { ...base, embeds: [embed] };
+}
+
+function buildBulkStatusEmbed({ total, completed, successes, failures, start, silent, done }) {
+  const durationSeconds = Math.max(0, (Date.now() - start) / 1000);
+  const embed = new EmbedBuilder()
+    .setTitle(done ? 'Bulk Bluesky download complete' : 'Bulk Bluesky download in progress')
+    .setColor(done ? (failures.length ? 0xe67e22 : 0x2ecc71) : 0x3498db)
+    .setDescription(
+      `Processing ${total} link${total === 1 ? '' : 's'} in ${silent ? 'silent' : 'standard'} mode.`
+    )
+    .addFields(
+      { name: 'Completed', value: `${completed}/${total}`, inline: true },
+      { name: 'Succeeded', value: `${successes}`, inline: true },
+      { name: 'Failed', value: `${failures.length}`, inline: true }
+    )
+    .addFields({ name: 'Elapsed', value: `${durationSeconds.toFixed(1)}s`, inline: true });
+
+  if (failures.length) {
+    const recent = failures.slice(-3).map((failure) => {
+      const message = truncateForField(failure.message);
+      return `• [Post](${failure.url}) — ${message}`;
+    });
+    embed.addFields({ name: 'Recent errors', value: recent.join('\n') });
+  }
+
+  return embed;
+}
+
+function truncateForField(text, maxLength = 256) {
+  if (!text) return 'Unknown error';
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return `${text.slice(0, maxLength - 1)}…`;
 }

--- a/src/commands.js
+++ b/src/commands.js
@@ -13,8 +13,6 @@ import { cleanupDownload, extractBlueskyPostLinks, fetchBlueskyVideo } from './b
 import { uploadToR2 } from './storage.js';
 import { config } from './config.js';
 
-const MAX_BULK_LINKS = 10;
-
 export const commandDefinitions = [
   new SlashCommandBuilder()
     .setName('bluesky-listener')
@@ -162,19 +160,6 @@ async function handleBulkDownloadCommand(interaction) {
         new EmbedBuilder()
           .setTitle('No Bluesky links found')
           .setDescription('Provide a comma separated list of Bluesky post URLs to download.')
-          .setColor(0xe74c3c),
-      ],
-      ephemeral: true,
-    });
-    return;
-  }
-
-  if (uniqueLinks.length > MAX_BULK_LINKS) {
-    await interaction.reply({
-      embeds: [
-        new EmbedBuilder()
-          .setTitle('Too many links')
-          .setDescription(`Bulk downloads are limited to ${MAX_BULK_LINKS} posts at a time.`)
           .setColor(0xe74c3c),
       ],
       ephemeral: true,

--- a/src/commands.js
+++ b/src/commands.js
@@ -11,6 +11,7 @@ import { saveGuildSettings } from './database.js';
 import { guildSettingsCache } from './settingsCache.js';
 import { cleanupDownload, extractBlueskyPostLinks, fetchBlueskyVideo } from './bluesky.js';
 import { uploadToR2 } from './storage.js';
+import { config } from './config.js';
 
 const MAX_BULK_LINKS = 10;
 
@@ -116,12 +117,14 @@ async function handleDownloadCommand(interaction) {
       fileName: download.fileName,
       contentType: download.mimeType ?? download.videoInfo?.mimeType,
     });
+    const attachFile = (download.fileSize ?? download.videoInfo?.size ?? 0) <= config.maxUploadBytes;
     const response = buildMessagePayload({
       download,
       requestedBy: interaction.user.username,
       postUrl: url,
       videoUrl: upload.publicUrl,
       silent,
+      attachFile,
     });
     await interaction.editReply(response);
   } catch (error) {
@@ -208,12 +211,14 @@ async function handleBulkDownloadCommand(interaction) {
         fileName: download.fileName,
         contentType: download.mimeType ?? download.videoInfo?.mimeType,
       });
+      const attachFile = (download.fileSize ?? download.videoInfo?.size ?? 0) <= config.maxUploadBytes;
       const payload = buildMessagePayload({
         download,
         requestedBy: interaction.user.username,
         postUrl: link.url,
         videoUrl: upload.publicUrl,
         silent,
+        attachFile,
       });
       await interaction.followUp(payload);
       successes += 1;
@@ -263,12 +268,14 @@ export async function handlePotentialBlueskyLinks(message) {
         fileName: download.fileName,
         contentType: download.mimeType ?? download.videoInfo?.mimeType,
       });
+      const attachFile = (download.fileSize ?? download.videoInfo?.size ?? 0) <= config.maxUploadBytes;
       const payload = buildMessagePayload({
         download,
         requestedBy: message.author.username,
         postUrl: link.url,
         videoUrl: upload.publicUrl,
         silent: settings.silentMode,
+        attachFile,
       });
       await message.channel.send(payload);
     } catch (error) {
@@ -285,7 +292,7 @@ export async function handlePotentialBlueskyLinks(message) {
   }
 }
 
-function buildVideoEmbed(download, requestedBy, url) {
+function buildVideoEmbed(download, requestedBy, url, { fallbackOnly = false, videoUrl } = {}) {
   const { post, author } = download;
   const embed = new EmbedBuilder()
     .setTitle(`Video from ${author?.displayName ?? author?.handle ?? 'Bluesky'}`)
@@ -302,11 +309,17 @@ function buildVideoEmbed(download, requestedBy, url) {
     embed.setFooter({ text: `Requested by ${requestedBy}` });
   }
 
+  if (fallbackOnly && videoUrl) {
+    embed.addFields({
+      name: 'Download link',
+      value: `[Open video](${videoUrl}) (hosted via Cloudflare R2)`,
+    });
+  }
+
   return embed;
 }
 
-function buildMessagePayload({ download, requestedBy, postUrl, videoUrl, silent }) {
-  const attachment = new AttachmentBuilder(download.filePath).setName(download.fileName);
+function buildMessagePayload({ download, requestedBy, postUrl, videoUrl, silent, attachFile = true }) {
   const components = [
     new ActionRowBuilder().addComponents(
       new ButtonBuilder().setLabel('Download').setStyle(ButtonStyle.Link).setURL(videoUrl)
@@ -314,16 +327,24 @@ function buildMessagePayload({ download, requestedBy, postUrl, videoUrl, silent 
   ];
 
   const base = {
-    files: [attachment],
     components,
     allowedMentions: { parse: [] },
   };
+
+  if (attachFile) {
+    base.files = [new AttachmentBuilder(download.filePath).setName(download.fileName)];
+  } else {
+    base.content = videoUrl;
+  }
 
   if (silent) {
     return base;
   }
 
-  const embed = buildVideoEmbed(download, requestedBy, postUrl);
+  const embed = buildVideoEmbed(download, requestedBy, postUrl, {
+    fallbackOnly: !attachFile,
+    videoUrl,
+  });
   return { ...base, embeds: [embed] };
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,57 @@
+import 'dotenv/config';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const requiredEnv = ['DISCORD_TOKEN', 'DISCORD_CLIENT_ID', 'DATABASE_URL'];
+
+for (const key of requiredEnv) {
+  if (!process.env[key]) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+}
+
+const defaultDataDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../data');
+
+const requiredR2Env = [
+  'R2_ACCOUNT_ID',
+  'R2_ACCESS_KEY_ID',
+  'R2_SECRET_ACCESS_KEY',
+  'R2_BUCKET_NAME',
+  'R2_PUBLIC_BASE_URL',
+];
+
+for (const key of requiredR2Env) {
+  if (!process.env[key]) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+}
+
+function normalizeBaseUrl(url) {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+function normalizePrefix(prefix) {
+  if (!prefix) return '';
+  const trimmed = prefix.replace(/^\/+/, '').replace(/\/+$/, '');
+  return trimmed ? `${trimmed}/` : '';
+}
+
+export const config = {
+  discordToken: process.env.DISCORD_TOKEN,
+  discordClientId: process.env.DISCORD_CLIENT_ID,
+  databaseUrl: process.env.DATABASE_URL,
+  downloadRoot: process.env.BOT_DATA_DIR || defaultDataDir,
+  commandGuildIds: process.env.DEV_GUILD_IDS ? process.env.DEV_GUILD_IDS.split(',').map((id) => id.trim()).filter(Boolean) : null,
+  maxUploadBytes: Number(process.env.MAX_UPLOAD_BYTES ?? 8 * 1024 * 1024),
+  ffmpegPath: process.env.FFMPEG_PATH || 'ffmpeg',
+  r2: {
+    accountId: process.env.R2_ACCOUNT_ID,
+    accessKeyId: process.env.R2_ACCESS_KEY_ID,
+    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+    bucketName: process.env.R2_BUCKET_NAME,
+    endpoint:
+      process.env.R2_ENDPOINT || `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+    publicBaseUrl: normalizeBaseUrl(process.env.R2_PUBLIC_BASE_URL),
+    objectPrefix: normalizePrefix(process.env.R2_OBJECT_PREFIX),
+  },
+};

--- a/src/database.js
+++ b/src/database.js
@@ -1,0 +1,62 @@
+import { Pool } from 'pg';
+import { config } from './config.js';
+
+const pool = new Pool({
+  connectionString: config.databaseUrl,
+  max: Number(process.env.PG_MAX_CLIENTS ?? 10),
+  idleTimeoutMillis: Number(process.env.PG_IDLE_TIMEOUT_MS ?? 30_000),
+});
+
+export async function initDatabase() {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS guild_settings (
+      guild_id TEXT PRIMARY KEY,
+      listen_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+      silent_mode BOOLEAN NOT NULL DEFAULT FALSE,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+  `);
+  await pool.query(
+    `ALTER TABLE guild_settings
+       ADD COLUMN IF NOT EXISTS silent_mode BOOLEAN NOT NULL DEFAULT FALSE`
+  );
+}
+
+export async function getGuildSettings(guildId) {
+  const result = await pool.query(
+    `SELECT listen_enabled, silent_mode FROM guild_settings WHERE guild_id = $1`,
+    [guildId]
+  );
+  if (result.rowCount === 0) {
+    return { listenEnabled: false, silentMode: false };
+  }
+  const row = result.rows[0];
+  return {
+    listenEnabled: Boolean(row.listen_enabled),
+    silentMode: Boolean(row.silent_mode),
+  };
+}
+
+export async function saveGuildSettings(guildId, updates) {
+  const current = await getGuildSettings(guildId);
+  const next = {
+    listenEnabled: updates.listenEnabled ?? current.listenEnabled ?? false,
+    silentMode: updates.silentMode ?? current.silentMode ?? false,
+  };
+
+  await pool.query(
+    `INSERT INTO guild_settings (guild_id, listen_enabled, silent_mode, updated_at)
+     VALUES ($1, $2, $3, NOW())
+     ON CONFLICT (guild_id)
+     DO UPDATE SET listen_enabled = EXCLUDED.listen_enabled,
+                   silent_mode = EXCLUDED.silent_mode,
+                   updated_at = NOW();`,
+    [guildId, next.listenEnabled, next.silentMode]
+  );
+
+  return next;
+}
+
+export async function shutdownDatabase() {
+  await pool.end();
+}

--- a/src/database.js
+++ b/src/database.js
@@ -20,6 +20,15 @@ export async function initDatabase() {
     `ALTER TABLE guild_settings
        ADD COLUMN IF NOT EXISTS silent_mode BOOLEAN NOT NULL DEFAULT FALSE`
   );
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS downloads (
+      id BIGSERIAL PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      bluesky_url TEXT NOT NULL,
+      r2_url TEXT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+  `);
 }
 
 export async function getGuildSettings(guildId) {
@@ -59,4 +68,16 @@ export async function saveGuildSettings(guildId, updates) {
 
 export async function shutdownDatabase() {
   await pool.end();
+}
+
+export async function recordDownload({ userId, blueskyUrl, r2Url }) {
+  if (!userId || !blueskyUrl || !r2Url) {
+    throw new Error('Missing download metadata');
+  }
+
+  await pool.query(
+    `INSERT INTO downloads (user_id, bluesky_url, r2_url)
+     VALUES ($1, $2, $3)`,
+    [userId, blueskyUrl, r2Url]
+  );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,83 @@
+import { Client, GatewayIntentBits, Partials, REST, Routes } from 'discord.js';
+import { config } from './config.js';
+import { initDatabase, shutdownDatabase } from './database.js';
+import { commandDefinitions, handleCommandInteraction, handlePotentialBlueskyLinks } from './commands.js';
+
+process.on('unhandledRejection', (error) => {
+  console.error('Unhandled promise rejection:', error);
+});
+
+async function main() {
+  await initDatabase();
+
+  const client = new Client({
+    intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent],
+    partials: [Partials.Channel],
+  });
+
+  client.once('ready', async () => {
+    console.log(`Logged in as ${client.user.tag}`);
+    try {
+      await registerCommands(client);
+      console.log('Slash commands registered.');
+    } catch (error) {
+      console.error('Failed to register commands:', error);
+    }
+  });
+
+  client.on('interactionCreate', async (interaction) => {
+    if (!interaction.isChatInputCommand()) return;
+    try {
+      await handleCommandInteraction(interaction);
+    } catch (error) {
+      console.error('Command handling error:', error);
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply({ content: 'Something went wrong while handling that command.' }).catch(() => {});
+      } else {
+        await interaction.reply({ content: 'Something went wrong while handling that command.', ephemeral: true }).catch(() => {});
+      }
+    }
+  });
+
+  client.on('messageCreate', async (message) => {
+    try {
+      await handlePotentialBlueskyLinks(message);
+    } catch (error) {
+      console.error('Message handling error:', error);
+    }
+  });
+
+  client.login(config.discordToken).catch((error) => {
+    console.error('Failed to log in to Discord:', error);
+    process.exit(1);
+  });
+
+  const shutdown = async () => {
+    console.log('Shutting down bot...');
+    await client.destroy();
+    await shutdownDatabase();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+async function registerCommands(client) {
+  const rest = new REST({ version: '10' }).setToken(config.discordToken);
+  const body = commandDefinitions;
+  if (config.commandGuildIds?.length) {
+    await Promise.all(
+      config.commandGuildIds.map((guildId) =>
+        rest.put(Routes.applicationGuildCommands(config.discordClientId, guildId), { body })
+      )
+    );
+  } else {
+    await rest.put(Routes.applicationCommands(config.discordClientId), { body });
+  }
+}
+
+main().catch((error) => {
+  console.error('Fatal error during startup:', error);
+  process.exit(1);
+});

--- a/src/settingsCache.js
+++ b/src/settingsCache.js
@@ -1,0 +1,27 @@
+import { getGuildSettings } from './database.js';
+
+class GuildSettingsCache {
+  constructor({ ttlMs = 60_000 } = {}) {
+    this.ttlMs = ttlMs;
+    this.cache = new Map();
+  }
+
+  async get(guildId) {
+    const existing = this.cache.get(guildId);
+    const now = Date.now();
+    if (existing && existing.expiresAt > now) {
+      return existing.value;
+    }
+    const value = await getGuildSettings(guildId);
+    this.cache.set(guildId, { value, expiresAt: now + this.ttlMs });
+    return value;
+  }
+
+  set(guildId, value) {
+    this.cache.set(guildId, { value, expiresAt: Date.now() + this.ttlMs });
+  }
+}
+
+export const guildSettingsCache = new GuildSettingsCache({
+  ttlMs: Number(process.env.SETTINGS_CACHE_TTL_MS ?? 60_000),
+});

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,67 @@
+import { createReadStream } from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { config } from './config.js';
+
+const s3Client = new S3Client({
+  region: 'auto',
+  endpoint: config.r2.endpoint,
+  credentials: {
+    accessKeyId: config.r2.accessKeyId,
+    secretAccessKey: config.r2.secretAccessKey,
+  },
+});
+
+function buildObjectKey(fileName) {
+  const baseName = path.basename(fileName).replace(/[^A-Za-z0-9._-]/g, '_');
+  const unique = `${Date.now()}-${crypto.randomUUID()}`;
+  return `${config.r2.objectPrefix}${unique}-${baseName}`;
+}
+
+function encodeKeyForUrl(key) {
+  return key
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+}
+
+export async function uploadToR2(filePath, { fileName, contentType } = {}) {
+  const finalName = fileName ?? path.basename(filePath);
+  const key = buildObjectKey(finalName);
+  const bodyStream = createReadStream(filePath);
+  const resolvedContentType = contentType ?? guessContentType(finalName) ?? 'video/mp4';
+  try {
+    await s3Client.send(
+      new PutObjectCommand({
+        Bucket: config.r2.bucketName,
+        Key: key,
+        Body: bodyStream,
+        ContentType: resolvedContentType,
+        ContentDisposition: `inline; filename="${finalName}"`,
+      })
+    );
+  } catch (error) {
+    bodyStream.destroy();
+    throw error;
+  }
+
+  const publicUrl = `${config.r2.publicBaseUrl}/${encodeKeyForUrl(key)}`;
+  return { key, publicUrl };
+}
+
+function guessContentType(fileName) {
+  const ext = path.extname(fileName).toLowerCase();
+  switch (ext) {
+    case '.mp4':
+      return 'video/mp4';
+    case '.mov':
+      return 'video/quicktime';
+    case '.webm':
+      return 'video/webm';
+    case '.ts':
+      return 'video/mp2t';
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Summary
- attach downloaded Bluesky videos directly to Discord messages while adding a download button that links to the Cloudflare R2 copy
- document the combined Discord attachment and Cloudflare hosting flow along with the silent-mode behaviour
- add a production-ready Dockerfile that installs ffmpeg and runs the bot via `npm start`

## Testing
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_68db338c1150832188efb9f38d11fb15