### PR TITLE
Fix critical security vulnerabilities

### DIFF
--- a/lms-system/backend/src/middleware/auth.ts
+++ b/lms-system/backend/src/middleware/auth.ts
@@ -21,10 +21,14 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
     throw new AppError(401, 'No authorization token provided');
   }
 
+  if (!process.env.JWT_SECRET) {
+    throw new AppError(500, 'JWT_SECRET environment variable is not configured');
+  }
+
   try {
     const decoded = jwt.verify(
       token,
-      process.env.JWT_SECRET || 'default-secret'
+      process.env.JWT_SECRET
     ) as any;
     req.user = decoded;
     next();

--- a/lms-system/backend/src/middleware/rateLimiter.ts
+++ b/lms-system/backend/src/middleware/rateLimiter.ts
@@ -40,7 +40,9 @@ export const rateLimiter = async (req: Request, res: Response, next: NextFunctio
     next();
   } catch (error) {
     logger.error('Rate limiting error:', error);
-    // On error, allow request to proceed but log it
-    next();
+    // Fail closed: reject request on rate limiter errors
+    return res.status(503).json({
+      error: 'Service temporarily unavailable'
+    });
   }
 };

--- a/lms-system/backend/src/routes/assignments.ts
+++ b/lms-system/backend/src/routes/assignments.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response, NextFunction } from 'express';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Decimal } from '@prisma/client';
 import { authMiddleware, requireRole } from '../middleware/auth';
 import { AppError } from '../middleware/errorHandler';
 

--- a/lms-system/backend/src/routes/assignments.ts
+++ b/lms-system/backend/src/routes/assignments.ts
@@ -154,10 +154,15 @@ router.post('/:submissionId/grade', authMiddleware, requireRole(['instructor', '
 
       const submission = await prisma.submission.findUnique({
         where: { id: BigInt(submissionId) },
-        include: { assignment: true }
+        include: { assignment: { include: { course: true } } }
       });
 
       if (!submission) throw new AppError(404, 'Submission not found');
+
+      // Verify instructor owns the course
+      if (submission.assignment.course.instructorId !== BigInt(req.user.id) && !req.user.roles.includes('admin')) {
+        throw new AppError(403, 'Not authorized to grade submissions in this course');
+      }
 
       const percentage = (points / submission.assignment.totalPoints) * 100;
       const letterGrade = getLetterGrade(percentage);

--- a/lms-system/backend/src/routes/auth.ts
+++ b/lms-system/backend/src/routes/auth.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import axios from 'axios';
+import bcrypt from 'bcryptjs';
 import { PrismaClient } from '@prisma/client';
 import { AppError } from '../middleware/errorHandler';
 import { authMiddleware } from '../middleware/auth';
@@ -27,20 +28,28 @@ const generateTokens = async (userId: bigint) => {
 
   const roles = user.roles.map(ur => ur.role.name);
 
+  if (!process.env.JWT_SECRET) {
+    throw new AppError(500, 'JWT_SECRET environment variable is not configured');
+  }
+
+  if (!process.env.JWT_REFRESH_SECRET) {
+    throw new AppError(500, 'JWT_REFRESH_SECRET environment variable is not configured');
+  }
+
   const accessToken = jwt.sign(
     { id: user.id.toString(), discordId: user.discordId, roles },
-    process.env.JWT_SECRET || 'default-secret',
+    process.env.JWT_SECRET,
     { expiresIn: process.env.JWT_EXPIRY || '15m' }
   );
 
   const refreshToken = jwt.sign(
     { id: user.id.toString(), discordId: user.discordId },
-    process.env.JWT_REFRESH_SECRET || 'default-secret',
+    process.env.JWT_REFRESH_SECRET,
     { expiresIn: process.env.JWT_REFRESH_EXPIRY || '7d' }
   );
 
   // Store refresh token
-  const hashedToken = Buffer.from(refreshToken).toString('base64');
+  const hashedToken = await bcrypt.hash(refreshToken, 10);
   await prisma.session.create({
     data: {
       userId: userId,
@@ -114,9 +123,22 @@ router.post('/discord/callback', async (req: Request, res: Response, next: NextF
 
     const { accessToken, refreshToken } = await generateTokens(user.id);
 
+    // Set httpOnly secure cookies instead of sending tokens in response body
+    res.cookie('accessToken', accessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      maxAge: 15 * 60 * 1000 // 15 minutes
+    });
+
+    res.cookie('refreshToken', refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
+    });
+
     res.json({
-      accessToken,
-      refreshToken,
       user: {
         id: user.id.toString(),
         discordId: user.discordId,
@@ -152,28 +174,38 @@ router.post('/refresh', async (req: Request, res: Response, next: NextFunction) 
       throw new AppError(400, 'Refresh token required');
     }
 
+    if (!process.env.JWT_REFRESH_SECRET) {
+      throw new AppError(500, 'JWT_REFRESH_SECRET environment variable is not configured');
+    }
+
     let decoded: any;
     try {
       decoded = jwt.verify(
         refreshToken,
-        process.env.JWT_REFRESH_SECRET || 'default-secret'
+        process.env.JWT_REFRESH_SECRET
       );
     } catch (error) {
       throw new AppError(401, 'Invalid or expired refresh token');
     }
 
     // CRITICAL FIX: Verify session is valid and not revoked
-    const hashedToken = Buffer.from(refreshToken).toString('base64');
-    const session = await prisma.session.findFirst({
+    const sessions = await prisma.session.findMany({
       where: {
         userId: BigInt(decoded.id),
-        refreshTokenHash: hashedToken,
         revokedAt: null,
         expiresAt: {
           gt: new Date() // Check expiration
         }
       }
     });
+
+    let session = null;
+    for (const s of sessions) {
+      if (await bcrypt.compare(refreshToken, s.refreshTokenHash)) {
+        session = s;
+        break;
+      }
+    }
 
     if (!session) {
       throw new AppError(401, 'Session invalid or revoked');
@@ -198,7 +230,22 @@ router.post('/refresh', async (req: Request, res: Response, next: NextFunction) 
       BigInt(decoded.id)
     );
 
-    res.json({ accessToken, refreshToken: newRefreshToken });
+    // Set httpOnly secure cookies instead of sending tokens in response body
+    res.cookie('accessToken', accessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      maxAge: 15 * 60 * 1000 // 15 minutes
+    });
+
+    res.cookie('refreshToken', newRefreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
+    });
+
+    res.json({ success: true });
   } catch (error) {
     next(error);
   }

--- a/lms-system/backend/src/routes/grades.ts
+++ b/lms-system/backend/src/routes/grades.ts
@@ -45,6 +45,18 @@ router.get('/course/:courseId/gradebook', authMiddleware, requireRole(['instruct
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const { courseId } = req.params;
+      if (!req.user) throw new AppError(401, 'Not authenticated');
+
+      // Verify course ownership
+      const course = await prisma.course.findUnique({
+        where: { id: BigInt(courseId) }
+      });
+
+      if (!course) throw new AppError(404, 'Course not found');
+
+      if (course.instructorId !== BigInt(req.user.id) && !req.user.roles.includes('admin')) {
+        throw new AppError(403, 'Not authorized to view this gradebook');
+      }
 
       const enrollments = await prisma.courseEnrollment.findMany({
         where: { courseId: BigInt(courseId) },
@@ -138,11 +150,37 @@ router.get('/student/:studentId', authMiddleware, requireRole(['admin']),
   }
 );
 
+// CSV injection prevention helper
+const escapeCSV = (value: string | number): string => {
+  const stringValue = String(value);
+  // Check for formula injection patterns
+  if (stringValue.match(/^[=+\-@]/)) {
+    return `'${stringValue}`;
+  }
+  // Quote fields containing commas, quotes, or newlines
+  if (stringValue.match(/[,"\n]/)) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+  return stringValue;
+};
+
 // Export gradebook as CSV
 router.get('/:courseId/export-csv', authMiddleware, requireRole(['instructor', 'admin']),
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const { courseId } = req.params;
+      if (!req.user) throw new AppError(401, 'Not authenticated');
+
+      // Verify course ownership
+      const course = await prisma.course.findUnique({
+        where: { id: BigInt(courseId) }
+      });
+
+      if (!course) throw new AppError(404, 'Course not found');
+
+      if (course.instructorId !== BigInt(req.user.id) && !req.user.roles.includes('admin')) {
+        throw new AppError(403, 'Not authorized to export this gradebook');
+      }
 
       const enrollments = await prisma.courseEnrollment.findMany({
         where: { courseId: BigInt(courseId) },
@@ -164,7 +202,7 @@ router.get('/:courseId/export-csv', authMiddleware, requireRole(['instructor', '
           ? grades.reduce((sum, g) => sum + (g.percentage?.toNumber() || 0), 0) / grades.length
           : 0;
 
-        csv += `${enrollment.studentId},${enrollment.student.username},${enrollment.student.email},${totalPoints},${avgPercentage.toFixed(2)},${getLetterGrade(avgPercentage)}\n`;
+        csv += `${escapeCSV(enrollment.studentId.toString())},${escapeCSV(enrollment.student.username)},${escapeCSV(enrollment.student.email)},${escapeCSV(totalPoints)},${escapeCSV(avgPercentage.toFixed(2))},${escapeCSV(getLetterGrade(avgPercentage))}\n`;
       }
 
       res.set({

--- a/lms-system/backend/src/routes/lessons.ts
+++ b/lms-system/backend/src/routes/lessons.ts
@@ -63,10 +63,24 @@ router.put('/:id', authMiddleware, requireRole(['instructor', 'admin']),
     try {
       const { id } = req.params;
       const { title, content, contentType, isPublished, durationMinutes } = req.body;
+      if (!req.user) throw new AppError(401, 'Not authenticated');
+
+      // Verify lesson exists and user owns the course
+      const lesson = await prisma.lesson.findUnique({
+        where: { id: BigInt(id) },
+        include: { module: { include: { course: true } } }
+      });
+
+      if (!lesson) throw new AppError(404, 'Lesson not found');
+
+      // Check authorization: must be instructor of the course or admin
+      if (lesson.module.course.instructorId !== BigInt(req.user.id) && !req.user.roles.includes('admin')) {
+        throw new AppError(403, 'Not authorized to update this lesson');
+      }
 
       const sanitizedContent = content !== undefined ? (content ? sanitizeContent(content) : null) : undefined;
 
-      const lesson = await prisma.lesson.update({
+      const updated = await prisma.lesson.update({
         where: { id: BigInt(id) },
         data: {
           ...(title && { title }),
@@ -77,7 +91,7 @@ router.put('/:id', authMiddleware, requireRole(['instructor', 'admin']),
         }
       });
 
-      res.json(lesson);
+      res.json(updated);
     } catch (error) {
       next(error);
     }
@@ -89,6 +103,26 @@ router.post('/:id/complete', authMiddleware, async (req: Request, res: Response,
   try {
     const { id } = req.params;
     if (!req.user) throw new AppError(401, 'Not authenticated');
+
+    // Verify lesson exists and student is enrolled in the course
+    const lesson = await prisma.lesson.findUnique({
+      where: { id: BigInt(id) },
+      include: { module: { include: { course: true } } }
+    });
+
+    if (!lesson) throw new AppError(404, 'Lesson not found');
+
+    // Check if student is enrolled in the course
+    const enrollment = await prisma.courseEnrollment.findFirst({
+      where: {
+        courseId: lesson.module.course.id,
+        studentId: BigInt(req.user.id)
+      }
+    });
+
+    if (!enrollment) {
+      throw new AppError(403, 'Not enrolled in this course');
+    }
 
     const completion = await prisma.lessonCompletion.upsert({
       where: {

--- a/lms-system/backend/src/routes/quizzes.ts
+++ b/lms-system/backend/src/routes/quizzes.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response, NextFunction } from 'express';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Decimal } from '@prisma/client';
 import { authMiddleware, requireRole } from '../middleware/auth';
 import { AppError } from '../middleware/errorHandler';
 
@@ -179,7 +179,12 @@ router.post('/:attemptId/submit', authMiddleware, async (req: Request, res: Resp
     const attempt = await prisma.quizAttempt.findUnique({
       where: { id: BigInt(attemptId) },
       include: {
-        quiz: { include: { questions: true } },
+        quiz: {
+          include: {
+            questions: true,
+            lesson: { include: { module: { include: { course: true } } } }
+          }
+        },
         answers: { include: { selectedOption: true, question: true } }
       }
     });
@@ -216,16 +221,19 @@ router.post('/:attemptId/submit', authMiddleware, async (req: Request, res: Resp
 
     // Create grade record
     if (passed) {
-      await prisma.grade.create({
-        data: {
-          quizAttemptId: BigInt(attemptId),
-          courseId: BigInt(1), // Should be fetched from context
-          studentId: attempt.studentId,
-          points: score,
-          percentage: percentage,
-          letterGrade: getLetterGrade(percentage)
-        }
-      });
+      const courseId = attempt.quiz.lesson?.module?.course?.id;
+      if (courseId) {
+        await prisma.grade.create({
+          data: {
+            quizAttemptId: BigInt(attemptId),
+            courseId: courseId,
+            studentId: attempt.studentId,
+            points: score,
+            percentage: percentage,
+            letterGrade: getLetterGrade(percentage)
+          }
+        });
+      }
     }
 
     res.json(updated);

--- a/lms-system/backend/src/routes/quizzes.ts
+++ b/lms-system/backend/src/routes/quizzes.ts
@@ -126,10 +126,25 @@ router.post('/:quizId/attempts', authMiddleware, async (req: Request, res: Respo
     if (!req.user) throw new AppError(401, 'Not authenticated');
 
     const quiz = await prisma.quiz.findUnique({
-      where: { id: BigInt(quizId) }
+      where: { id: BigInt(quizId) },
+      include: { lesson: { include: { module: { include: { course: true } } } } }
     });
 
     if (!quiz) throw new AppError(404, 'Quiz not found');
+
+    // Verify student is enrolled in the course
+    if (quiz.lesson) {
+      const enrollment = await prisma.courseEnrollment.findFirst({
+        where: {
+          courseId: quiz.lesson.module.course.id,
+          studentId: BigInt(req.user.id)
+        }
+      });
+
+      if (!enrollment) {
+        throw new AppError(403, 'Not enrolled in this course');
+      }
+    }
 
     const attempt = await prisma.quizAttempt.create({
       data: {
@@ -154,6 +169,17 @@ router.post('/:attemptId/answers', authMiddleware, async (req: Request, res: Res
     if (!req.user) throw new AppError(401, 'Not authenticated');
 
     if (!questionId) throw new AppError(400, 'Question ID required');
+
+    // Verify the attempt belongs to the authenticated user
+    const attempt = await prisma.quizAttempt.findUnique({
+      where: { id: BigInt(attemptId) }
+    });
+
+    if (!attempt) throw new AppError(404, 'Attempt not found');
+
+    if (attempt.studentId !== BigInt(req.user.id)) {
+      throw new AppError(403, 'Not authorized to submit answers for this attempt');
+    }
 
     const answer = await prisma.quizAnswer.create({
       data: {

--- a/lms-system/backend/src/utils/redis.ts
+++ b/lms-system/backend/src/utils/redis.ts
@@ -11,9 +11,11 @@ export class RedisClient {
   private redis: any = null;
   private inMemoryStore: RateLimitStore = {};
   private useRedis: boolean = false;
+  private cleanupInterval: NodeJS.Timeout | null = null;
 
   constructor() {
     this.initialize();
+    this.startCleanupInterval();
   }
 
   private initialize() {
@@ -29,6 +31,24 @@ export class RedisClient {
       console.log('Redis initialization failed, using in-memory storage');
       this.useRedis = false;
     }
+  }
+
+  private startCleanupInterval() {
+    // Clean up expired entries every hour
+    this.cleanupInterval = setInterval(() => {
+      const now = Date.now();
+      let deletedCount = 0;
+      for (const [key, entry] of Object.entries(this.inMemoryStore)) {
+        // Delete entries that expired more than 24 hours ago
+        if (now > entry.resetTime + 86400000) {
+          delete this.inMemoryStore[key];
+          deletedCount++;
+        }
+      }
+      if (deletedCount > 0) {
+        console.log(`Cleaned up ${deletedCount} expired rate limit entries`);
+      }
+    }, 3600000); // Run every hour
   }
 
   async incrementCounter(key: string, windowMs: number): Promise<number> {

--- a/lms-system/frontend/src/pages/LessonPage.tsx
+++ b/lms-system/frontend/src/pages/LessonPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Button, Card, CircularProgress, Typography } from '@mui/material';
 import { useParams } from 'react-router-dom';
+import ReactMarkdown from 'react-markdown';
 import { apiClient } from '../utils/api';
 
 const LessonPage: React.FC = () => {
@@ -43,10 +44,9 @@ const LessonPage: React.FC = () => {
       </Typography>
 
       <Card sx={{ p: 4, mb: 3 }}>
-        <div
-          dangerouslySetInnerHTML={{ __html: lesson.content }}
-          style={{ marginBottom: 20 }}
-        />
+        <Box sx={{ marginBottom: 20 }}>
+          <ReactMarkdown>{lesson.content || ''}</ReactMarkdown>
+        </Box>
         <Button variant="contained" color="success" onClick={handleCompleteLesson}>
           Mark as Complete
         </Button>

--- a/lms-system/frontend/src/store/authStore.ts
+++ b/lms-system/frontend/src/store/authStore.ts
@@ -12,11 +12,8 @@ export interface User {
 
 export interface AuthState {
   user: User | null;
-  accessToken: string | null;
-  refreshToken: string | null;
   isAuthenticated: boolean;
   setUser: (user: User | null) => void;
-  setTokens: (accessToken: string, refreshToken: string) => void;
   logout: () => void;
 }
 
@@ -24,22 +21,21 @@ export const useAuthStore = create<AuthState>(
   persist(
     (set) => ({
       user: null,
-      accessToken: null,
-      refreshToken: null,
       isAuthenticated: false,
       setUser: (user) => set({ user, isAuthenticated: !!user }),
-      setTokens: (accessToken, refreshToken) =>
-        set({ accessToken, refreshToken, isAuthenticated: true }),
       logout: () =>
         set({
           user: null,
-          accessToken: null,
-          refreshToken: null,
           isAuthenticated: false,
         }),
     }),
     {
       name: 'auth-storage',
+      // Only persist user info, not sensitive tokens
+      partialize: (state) => ({
+        user: state.user,
+        isAuthenticated: state.isAuthenticated,
+      }),
     }
   )
 );


### PR DESCRIPTION
- Fix hardcoded JWT secrets: Remove fallback 'default-secret' and throw errors if JWT_SECRET or JWT_REFRESH_SECRET environment variables are not configured
- Fix insecure refresh token storage: Replace base64 encoding with bcryptjs hashing (10 rounds) to prevent token recovery if database is breached
- Fix missing Decimal import in quizzes.ts and assignments.ts: Import Decimal from @prisma/client to prevent ReferenceError at runtime when calculating percentages
- Fix hardcoded courseId in quiz grading: Fetch actual courseId from quiz->lesson->module->course relationship instead of hardcoding to BigInt(1)
- Fix JWT tokens in localStorage: Move from localStorage persistence to httpOnly secure cookies in backend auth responses, remove token storage from frontend authStore